### PR TITLE
Caching extension

### DIFF
--- a/src/client_manager.cc
+++ b/src/client_manager.cc
@@ -583,10 +583,15 @@ namespace laps {
                     SPDLOG_DEBUG("Subscribe: Publishing object from cache: Group {0} is Object {1}",
                                 object.headers.group_id,
                                 object.headers.object_id);
+                    if (!config_.cache_key.has_value()) {
+                        pub_track_h->PublishObject(object.headers, object.data);
+                        continue;
+                    }
+
+                    // Mark as cached.
                     auto headers = object.headers;
                     auto extensions = headers.extensions.value_or(quicr::Extensions());
-                    const std::uint64_t cached = 100;
-                    extensions[cached] = {0x01};
+                    extensions[*config_.cache_key] = {0x01};
                     headers.extensions = extensions;
                     pub_track_h->PublishObject(headers, object.data);
                 }

--- a/src/config.h
+++ b/src/config.h
@@ -35,6 +35,7 @@ namespace laps {
         peering::NodeType node_type{ peering::NodeType::kEdge }; /// Node type of the relay
 
         std::shared_ptr<quicr::ThreadedTickService> tick_service_;
+        std::optional<std::uint64_t> cache_key = std::nullopt;
 
         struct Peering
         {

--- a/src/main.cc
+++ b/src/main.cc
@@ -79,6 +79,10 @@ InitConfig(cxxopts::ParseResult& cli_opts, Config& cfg)
 
     cfg.relay_id_ = cli_opts["endpoint_id"].as<std::string>();
 
+    if (cli_opts.count("cache_key")) {
+        cfg.cache_key = cli_opts["cache_key"].as<std::uint64_t>();
+    }
+
     config.endpoint_id = cfg.relay_id_;
     config.server_bind_ip = cli_opts["bind_ip"].as<std::string>();
     config.server_port = cli_opts["port"].as<uint16_t>();
@@ -115,7 +119,9 @@ main(int argc, char* argv[])
         "q,qlog", "Enable qlog using path", cxxopts::value<std::string>())(
         "cache_duration",
         "Duration of cache objects in milliseconds",
-        cxxopts::value<size_t>()->default_value("60000")); // end of options
+        cxxopts::value<size_t>()->default_value("60000"))("cache_key",
+                                                          "Value of isCached extension key",
+                                                          cxxopts::value<std::uint64_t>()); // end of options
 
     options.add_options("Peering")("peer_port",
                                    "Listening port for peering connections",


### PR DESCRIPTION
Adds the ability to append an extension header to mark that the given object has come from the cache. I didn't want to add any overhead, so this is off by default. The key is configurable, and the value is just `1`. 