### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ sudo apt-get install -y make cmake openssl golang wget git ca-certificates
 # Hit enter through the prompts
 ssh-keygen
 
-cat ~/.ssh/id_rsa.pub
+cat ~/.ssh/<output_of_ssh-keygen>.pub
 ```
 
 Goto github, under **settings**, then under **SSH and GPG keys**, add a new SSH key with the contents of the above


### PR DESCRIPTION
minor update to make it clearer for the next user. the ssh-keygen command spits out the name of the .pub file, so the cat command needs to use that filename. 