### PR TITLE
Revert "hot fix for fetch end-object"

### DIFF
--- a/src/client_manager.cc
+++ b/src/client_manager.cc
@@ -934,7 +934,7 @@ namespace laps {
                     }
 
                     if (end->object && object.headers.group_id == end->group &&
-                        object.headers.object_id > end->object) {
+                        object.headers.object_id >= end->object) {
                         return;
                     }
 


### PR DESCRIPTION
This reverts commit 9b0320a4f1261ddc67888ca27e124ddc88d8a02c.

Now that we fixed up some FETCH work in libquicr, and clarification that end object is *currently* always +1'd in libquicr, this needs to be reverted so that an object ID of `end->object ` is NOT delivered (as `end->object` is the last desired location + 1 / exclusive range). 