### PR TITLE
Set track filter from messages if present

### DIFF
--- a/src/client_manager.cc
+++ b/src/client_manager.cc
@@ -179,7 +179,7 @@ namespace laps {
                       sub_ftn, 0, quicr::messages::GroupOrder::kOriginalPublisherOrder, *this, config_.tick_service_);
 
                     // Add subsribers to publisher subscribe handler
-                    for (const auto& sub_info: sub_tracks) {
+                    for (const auto& sub_info : sub_tracks) {
                         sub_track_handler->AddSubscriber(sub_info.connection_handle,
                                                          sub_info.request_id,
                                                          sub_info.priority,
@@ -387,6 +387,19 @@ namespace laps {
         }
 
         auto [ranks_it, __] = track_rankings_.try_emplace(th.track_namespace_hash, std::make_shared<TrackRanking>());
+
+        if (const auto* tf = std::get_if<quicr::messages::TrackFilter>(&attributes.filter)) {
+            SPDLOG_INFO("Subscribe namespace track filter: property_type={} max_tracks={} timeout={}ms",
+                        tf->property_type,
+                        tf->max_tracks_selected,
+                        tf->max_time_selected);
+            handler->SetMaxSelected(tf->max_tracks_selected);
+            handler->SetInactiveAge(tf->max_time_selected);
+            handler->SetPropertyType(tf->property_type);
+        } else {
+            SPDLOG_INFO("Subscribe namespace has no track filter, using defaults");
+        }
+
         ranks_it->second->AddNamespaceHandler(handler);
 
         std::vector<quicr::TrackNamespace> matched_ns;

--- a/src/publish_namespace_handler.h
+++ b/src/publish_namespace_handler.h
@@ -63,9 +63,13 @@ namespace laps {
         constexpr void SetInactiveAge(const uint64_t age_ms) { inactive_age_ms_ = age_ms; }
         constexpr uint64_t GetInactiveAge() { return inactive_age_ms_; }
 
+        constexpr void SetPropertyType(const uint64_t prop) { property_type_ = prop; }
+        constexpr uint64_t GetPropertyType() { return property_type_; }
+
       private:
         uint64_t max_tracks_selected_{ 1 };     // Max tracks to select as candidate top-n
         uint64_t inactive_age_ms_{ 3000 };      // Age in ms of a track that is considered stale/inactive
+        uint64_t property_type_{ 12 };          // Property type to rank by
         uint64_t delay_publish_done_ms_{ 900 }; // Delay sending publish done to allow publish to come back
 
         std::weak_ptr<quicr::TickService> tick_service_;

--- a/src/subscribe_handler.cc
+++ b/src/subscribe_handler.cc
@@ -46,6 +46,12 @@ namespace laps {
 
         sub_namespaces_[th.track_fullname_hash].emplace(handler->GetConnectionId(), handler);
 
+        auto prop = handler->GetPropertyType();
+        if (!tracked_properties_value_.contains(prop)) {
+            SPDLOG_INFO("Subscribe handler tracking property_type={} from namespace handler", prop);
+            tracked_properties_value_.emplace(prop, PublishNamespaceHandler::TrackPropertyValue{});
+        }
+
         Resume();
     }
 


### PR DESCRIPTION
I've left the hardcoded defaults in for if there's no filter just for now. We can fix that up. It'll only work if we all have the same, but should work in the immediate term for us. 