### PR TITLE
Add echo flag for sub-ns

### DIFF
--- a/src/client_manager.cc
+++ b/src/client_manager.cc
@@ -272,7 +272,7 @@ namespace laps {
         for (auto& [tn, conns] : state_.subscribes_namespaces) {
             if (tn.HasSamePrefix(publish_attributes.track_full_name.name_space)) {
                 for (auto& [_, pub_ns_h] : conns) {
-                    if (pub_ns_h->GetConnectionId() == connection_handle) {
+                    if (!config_.echo && pub_ns_h->GetConnectionId() == connection_handle) {
                         // Initially do not mirror
                         continue;
                     }
@@ -402,7 +402,7 @@ namespace laps {
         // TODO: Need to change this to use what peering is using to prefix match instead of O(n) over all publish
         //  subscribes
         for (const auto& [ta_conn, handler] : state_.pub_subscribes) {
-            if (ta_conn.second == connection_handle || !handler) {
+            if (!handler || (!config_.echo && ta_conn.second == connection_handle)) {
                 continue;
             }
 
@@ -471,7 +471,7 @@ namespace laps {
 
         // Loop through publishes and remove subscribe namespace
         for (const auto& [ta_conn, handler] : state_.pub_subscribes) {
-            if (ta_conn.second == connection_handle || !handler) {
+            if (!handler || (!config_.echo && ta_conn.second == connection_handle)) {
                 continue;
             }
 

--- a/src/client_manager.cc
+++ b/src/client_manager.cc
@@ -272,7 +272,7 @@ namespace laps {
         for (auto& [tn, conns] : state_.subscribes_namespaces) {
             if (tn.HasSamePrefix(publish_attributes.track_full_name.name_space)) {
                 for (auto& [_, pub_ns_h] : conns) {
-                    if (!config_.echo && pub_ns_h->GetConnectionId() == connection_handle) {
+                    if (!config_.allow_self && pub_ns_h->GetConnectionId() == connection_handle) {
                         // Initially do not mirror
                         continue;
                     }
@@ -402,7 +402,7 @@ namespace laps {
         // TODO: Need to change this to use what peering is using to prefix match instead of O(n) over all publish
         //  subscribes
         for (const auto& [ta_conn, handler] : state_.pub_subscribes) {
-            if (!handler || (!config_.echo && ta_conn.second == connection_handle)) {
+            if (!handler || (!config_.allow_self && ta_conn.second == connection_handle)) {
                 continue;
             }
 
@@ -471,7 +471,7 @@ namespace laps {
 
         // Loop through publishes and remove subscribe namespace
         for (const auto& [ta_conn, handler] : state_.pub_subscribes) {
-            if (!handler || (!config_.echo && ta_conn.second == connection_handle)) {
+            if (!handler || (!config_.allow_self && ta_conn.second == connection_handle)) {
                 continue;
             }
 

--- a/src/config.h
+++ b/src/config.h
@@ -32,7 +32,7 @@ namespace laps {
         bool debug{ false }; /// Debug logging/code
         bool use_reset_wait_strategy{ false };
         bool detached_subs{ false };
-        bool echo{ false };
+        bool allow_self{ false };
 
         std::string relay_id_;
         std::string tls_cert_filename_;

--- a/src/config.h
+++ b/src/config.h
@@ -32,6 +32,7 @@ namespace laps {
         bool debug{ false }; /// Debug logging/code
         bool use_reset_wait_strategy{ false };
         bool detached_subs{ false };
+        bool echo{ false };
 
         std::string relay_id_;
         std::string tls_cert_filename_;

--- a/src/main.cc
+++ b/src/main.cc
@@ -48,6 +48,11 @@ InitConfig(cxxopts::ParseResult& cli_opts, Config& cfg)
         cfg.detached_subs = true;
     }
 
+    if (cli_opts.count("echo") && cli_opts["echo"].as<bool>() == true) {
+        SPDLOG_LOGGER_INFO(cfg.logger_, "Enabling subscribe namespace echo");
+        cfg.echo = true;
+    }
+
     if (cli_opts.count("peer")) {
         for (auto& peer : cli_opts["peer"].as<std::vector<std::string>>()) {
             auto port_pos = peer.find(":");
@@ -148,7 +153,8 @@ main(int argc, char* argv[])
             "Duration of cache objects in milliseconds",
             cxxopts::value<size_t>()->default_value("60000"))
         ("cache_key", "Value of isCached extension key", cxxopts::value<std::uint64_t>())
-        ("l,detached_subs", "Enable support for detached subscribers");
+        ("l,detached_subs", "Enable support for detached subscribers")
+        ("echo", "Allow subscribe namespace self-subscriptions");
 
 
     options.add_options("Peering")

--- a/src/main.cc
+++ b/src/main.cc
@@ -48,9 +48,9 @@ InitConfig(cxxopts::ParseResult& cli_opts, Config& cfg)
         cfg.detached_subs = true;
     }
 
-    if (cli_opts.count("echo") && cli_opts["echo"].as<bool>() == true) {
-        SPDLOG_LOGGER_INFO(cfg.logger_, "Enabling subscribe namespace echo");
-        cfg.echo = true;
+    if (cli_opts.count("allow_self") && cli_opts["allow_self"].as<bool>() == true) {
+        SPDLOG_LOGGER_INFO(cfg.logger_, "Enabling subscribe namespace self-subscriptions");
+        cfg.allow_self = true;
     }
 
     if (cli_opts.count("peer")) {
@@ -154,7 +154,7 @@ main(int argc, char* argv[])
             cxxopts::value<size_t>()->default_value("60000"))
         ("cache_key", "Value of isCached extension key", cxxopts::value<std::uint64_t>())
         ("l,detached_subs", "Enable support for detached subscribers")
-        ("echo", "Allow subscribe namespace self-subscriptions");
+        ("allow_self", "Allow subscribe namespace self-subscriptions");
 
 
     options.add_options("Peering")


### PR DESCRIPTION
Adds `--echo` to opt-into receiving self subscriptions from subscribe namespace. I keep re-applying this for testing and figured we could throw it in. 