### PR TITLE
Add metrics exporter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set (CMAKE_POLICY_VERSION_MINIMUM 3.5)
 ### Define the project name and version
 ###       Version will be added to version output of apps and library
 project(laps
-        VERSION 0.18.7
+        VERSION 0.18.8
         DESCRIPTION "Latency Aware Publish/Subscribe"
         LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set (CMAKE_POLICY_VERSION_MINIMUM 3.5)
 ### Define the project name and version
 ###       Version will be added to version output of apps and library
 project(laps
-        VERSION 0.18.3
+        VERSION 0.18.7
         DESCRIPTION "Latency Aware Publish/Subscribe"
         LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set (CMAKE_POLICY_VERSION_MINIMUM 3.5)
 ### Define the project name and version
 ###       Version will be added to version output of apps and library
 project(laps
-        VERSION 0.18.8
+        VERSION 0.18.10
         DESCRIPTION "Latency Aware Publish/Subscribe"
         LANGUAGES CXX)
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -4,13 +4,13 @@ LAPS publishes relay metrics over MoQ tracks as newline-delimited JSON. Metrics 
 
 ## Transport
 
-The metrics publisher starts when the relay starts and stops with the relay. Each `MetricsSampled()` callback serializes the sample to one JSON object plus a trailing newline and pushes it into a `quicr::SafeQueue`. The metrics thread blocks on that queue and publishes each JSON line through relay-local publish tracks.
+The metrics publisher starts when the relay starts and stops with the relay. Each `MetricsSampled()` callback serializes the sample to one JSON object plus a trailing newline and pushes it into a `quicr::SafeQueue`. The metrics thread blocks on that queue and publishes each JSON line through a relay-local publish track.
 
 The queue is bounded. If the queue is full, the oldest queued sample is dropped and the new sample is kept.
 
-The relay registers the metrics tracks as self-published tracks using connection handle `0`; it does not publish metrics back through the client connection that emitted the sample. Normal `SUBSCRIBE` and `SUBSCRIBE_TRACKS` matching then forwards metrics objects to interested subscribers the same way it forwards objects from other publishers.
+The relay registers the metrics track as a self-published track using connection handle `0`; it does not publish metrics back through the client connection that emitted the sample. Normal `SUBSCRIBE` and `SUBSCRIBE_TRACKS` matching then forwards metrics objects to interested subscribers the same way it forwards objects from other publishers.
 
-Metrics are forwarded as MoQ objects using stream track mode. Group IDs increase per metrics track, with `object_id` and `subgroup_id` set to `0`.
+Metrics are forwarded as MoQ objects using stream track mode. Group IDs increase on the metrics track, with `object_id` and `subgroup_id` set to `0`.
 
 ## Tracks
 
@@ -28,9 +28,15 @@ lapsRelay --metrics_namespace custom/metrics/namespace
 
 The relay logs the namespace on startup. Slash-separated namespace strings are converted to MoQ namespace tuple entries.
 
-Each metrics type is published on a separate track name under the metrics namespace:
+All metrics types are published on one schema-versioned track name under the metrics namespace:
 
-| Track name | Source callback |
+```text
+laps.metrics.openapi.v1
+```
+
+The track name identifies the OpenAPI schema used by every JSON line. The metric variant is identified by the JSON `type` field:
+
+| `type` | Source callback |
 | --- | --- |
 | `connection` | `ClientManager::MetricsSampled(connection_handle, ConnectionMetrics)` |
 | `subscribe` | `SubscribeTrackHandler::MetricsSampled(SubscribeTrackMetrics)` |
@@ -40,8 +46,10 @@ For example, with relay ID `relay-a`, consumers can subscribe to:
 
 ```text
 namespace: metrics/relay-a
-name: connection
+name: laps.metrics.openapi.v1
 ```
+
+The OpenAPI 3.1 schema is published in [`docs/metrics.openapi.yaml`](metrics.openapi.yaml). It defines a `MetricsSample` schema with a `type` discriminator over `connection`, `subscribe`, and `publish` payloads.
 
 ## Common Fields
 
@@ -49,7 +57,7 @@ All metrics JSON objects include:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `type` | string | Metrics type: `connection`, `subscribe`, or `publish`. |
+| `type` | string | Metrics discriminator: `connection`, `subscribe`, or `publish`. |
 | `relay_id` | string | Relay endpoint ID. |
 | `sample_time_us` | unsigned integer | Sample timestamp in microseconds since Unix epoch. |
 | `connection_handle` | unsigned integer | libquicr connection handle associated with the sample. |
@@ -80,7 +88,7 @@ Several QUIC fields use the same min/max/average shape:
 
 ## Connection Metrics
 
-Connection metrics are emitted on track name `connection`.
+Connection metrics are emitted on the schema track with `type` set to `connection`.
 
 Example:
 
@@ -133,7 +141,7 @@ Connection `quic` fields:
 
 ## Subscribe Metrics
 
-Subscribe metrics are emitted on track name `subscribe`.
+Subscribe metrics are emitted on the schema track with `type` set to `subscribe`.
 
 Example:
 
@@ -153,7 +161,7 @@ Subscribe-specific fields:
 
 ## Publish Metrics
 
-Publish metrics are emitted on track name `publish`.
+Publish metrics are emitted on the schema track with `type` set to `publish`.
 
 Example:
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -10,7 +10,7 @@ The queue is bounded. If the queue is full, the oldest queued sample is dropped 
 
 The relay registers the metrics tracks as self-published tracks using connection handle `0`; it does not publish metrics back through the client connection that emitted the sample. Normal `SUBSCRIBE` and `SUBSCRIBE_TRACKS` matching then forwards metrics objects to interested subscribers the same way it forwards objects from other publishers.
 
-Metrics are forwarded as MoQ objects using datagram track mode. Object IDs increase per metrics track, with `group_id` set to `0`.
+Metrics are forwarded as MoQ objects using stream track mode. Object IDs increase per metrics track, with `group_id` and `subgroup_id` set to `0`.
 
 ## Tracks
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -147,7 +147,7 @@ Subscribe metrics are emitted on the schema track with `type` set to `subscribe`
 Example:
 
 ```json
-{"type":"subscribe","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"track_namespace":"media/live/event1","track_name":"video","bytes_received":8192,"objects_received":32,"subscribers":4}
+{"type":"subscribe","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"track_namespace":"media/live/event1","track_name":"video","bytes_received":8192,"objects_received":32}
 ```
 
 Subscribe-specific fields:
@@ -158,7 +158,6 @@ Subscribe-specific fields:
 | `track_name` | Name of the subscribed content track. |
 | `bytes_received` | Payload bytes received during the sample period. |
 | `objects_received` | Objects received during the sample period. |
-| `subscribers` | Current number of local fanout subscribers for the track. |
 
 ## Publish Metrics
 
@@ -167,7 +166,7 @@ Publish metrics are emitted on the schema track with `type` set to `publish`.
 Example:
 
 ```json
-{"type":"publish","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"remote_endpoint_id":"client-42","track_namespace":"media/live/event1","track_name":"video","bytes_published":16384,"objects_published":64,"objects_dropped_not_ok":0,"quic":{"tx_buffer_drops":0,"tx_queue_discards":0,"tx_queue_expired":0,"tx_delayed_callback":0,"tx_reset_wait":0,"tx_queue_size":{"min":0,"max":3,"avg":1,"value_sum":6,"value_count":4},"tx_callback_ms":{"min":0,"max":2,"avg":1,"value_sum":4,"value_count":4},"tx_object_duration_us":{"min":100,"max":500,"avg":250,"value_sum":1000,"value_count":4}}}
+{"type":"publish","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"remote_endpoint_id":"client-42","track_namespace":"media/live/event1","track_name":"video","bytes_published":16384,"objects_published":64,"objects_dropped_not_ok":0,"subscribers":4,"quic":{"tx_buffer_drops":0,"tx_queue_discards":0,"tx_queue_expired":0,"tx_delayed_callback":0,"tx_reset_wait":0,"tx_queue_size":{"min":0,"max":3,"avg":1,"value_sum":6,"value_count":4},"tx_callback_ms":{"min":0,"max":2,"avg":1,"value_sum":4,"value_count":4},"tx_object_duration_us":{"min":100,"max":500,"avg":250,"value_sum":1000,"value_count":4}}}
 ```
 
 Publish-specific fields:
@@ -180,6 +179,7 @@ Publish-specific fields:
 | `bytes_published` | Payload bytes published during the sample period. |
 | `objects_published` | Objects published during the sample period. |
 | `objects_dropped_not_ok` | Objects dropped because the publish handler was not in a publishable state. |
+| `subscribers` | Current number of local fanout subscribers for the track. Track-level, so every publish sample for the same track in a period carries the same value. Subscribers matched through a subscribe namespace are not counted. |
 | `quic` | QUIC data-context metrics object. |
 
 Publish `quic` fields:

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -10,7 +10,7 @@ The queue is bounded. If the queue is full, the oldest queued sample is dropped 
 
 The relay registers the metrics tracks as self-published tracks using connection handle `0`; it does not publish metrics back through the client connection that emitted the sample. Normal `SUBSCRIBE` and `SUBSCRIBE_TRACKS` matching then forwards metrics objects to interested subscribers the same way it forwards objects from other publishers.
 
-Metrics are forwarded as MoQ objects using stream track mode. Object IDs increase per metrics track, with `group_id` and `subgroup_id` set to `0`.
+Metrics are forwarded as MoQ objects using stream track mode. Group IDs increase per metrics track, with `object_id` and `subgroup_id` set to `0`.
 
 ## Tracks
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -93,13 +93,14 @@ Connection metrics are emitted on the schema track with `type` set to `connectio
 Example:
 
 ```json
-{"type":"connection","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"remote_ip":"192.0.2.44","remote_port":54431,"publish_tracks":3,"rx_dgram_unknown_track_alias":0,"rx_dgram_invalid_type":0,"rx_dgram_decode_failed":0,"rx_stream_buffer_error":0,"rx_stream_unknown_track_alias":0,"rx_stream_invalid_type":0,"invalid_ctrl_stream_msg":0,"quic":{"cwin_congested":0,"prev_cwin_congested":0,"tx_congested":0,"tx_rate_bps":{"min":1000,"max":2000,"avg":1500,"value_sum":3000,"value_count":2},"rx_rate_bps":{"min":900,"max":1800,"avg":1350,"value_sum":2700,"value_count":2},"tx_cwin_bytes":{"min":12000,"max":16000,"avg":14000,"value_sum":28000,"value_count":2},"tx_in_transit_bytes":{"min":0,"max":8000,"avg":4000,"value_sum":8000,"value_count":2},"rtt_us":{"min":1000,"max":1400,"avg":1200,"value_sum":2400,"value_count":2},"srtt_us":{"min":1100,"max":1300,"avg":1200,"value_sum":2400,"value_count":2},"tx_retransmits":0,"tx_lost_pkts":0,"tx_timer_losses":0,"tx_spurious_losses":0,"rx_dgrams":12,"rx_dgrams_bytes":4096,"tx_dgram_cb":15,"tx_dgram_ack":14,"tx_dgram_lost":0,"tx_dgram_spurious":0,"tx_dgram_drops":0}}
+{"type":"connection","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"remote_endpoint_id":"client-42","remote_ip":"192.0.2.44","remote_port":54431,"publish_tracks":3,"rx_dgram_unknown_track_alias":0,"rx_dgram_invalid_type":0,"rx_dgram_decode_failed":0,"rx_stream_buffer_error":0,"rx_stream_unknown_track_alias":0,"rx_stream_invalid_type":0,"invalid_ctrl_stream_msg":0,"quic":{"cwin_congested":0,"prev_cwin_congested":0,"tx_congested":0,"tx_rate_bps":{"min":1000,"max":2000,"avg":1500,"value_sum":3000,"value_count":2},"rx_rate_bps":{"min":900,"max":1800,"avg":1350,"value_sum":2700,"value_count":2},"tx_cwin_bytes":{"min":12000,"max":16000,"avg":14000,"value_sum":28000,"value_count":2},"tx_in_transit_bytes":{"min":0,"max":8000,"avg":4000,"value_sum":8000,"value_count":2},"rtt_us":{"min":1000,"max":1400,"avg":1200,"value_sum":2400,"value_count":2},"srtt_us":{"min":1100,"max":1300,"avg":1200,"value_sum":2400,"value_count":2},"tx_retransmits":0,"tx_lost_pkts":0,"tx_timer_losses":0,"tx_spurious_losses":0,"rx_dgrams":12,"rx_dgrams_bytes":4096,"tx_dgram_cb":15,"tx_dgram_ack":14,"tx_dgram_lost":0,"tx_dgram_spurious":0,"tx_dgram_drops":0}}
 ```
 
 Connection-specific fields:
 
 | Field | Description |
 | --- | --- |
+| `remote_endpoint_id` | Remote endpoint ID from the client's `CLIENT_SETUP`. Empty until setup is received. |
 | `remote_ip` | Remote client IP address recorded when the connection was accepted. Empty if unavailable. |
 | `remote_port` | Remote client UDP port recorded when the connection was accepted. `0` if unavailable. |
 | `publish_tracks` | Number of active publish tracks for this connection. |
@@ -166,13 +167,14 @@ Publish metrics are emitted on the schema track with `type` set to `publish`.
 Example:
 
 ```json
-{"type":"publish","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"track_namespace":"media/live/event1","track_name":"video","bytes_published":16384,"objects_published":64,"objects_dropped_not_ok":0,"quic":{"tx_buffer_drops":0,"tx_queue_discards":0,"tx_queue_expired":0,"tx_delayed_callback":0,"tx_reset_wait":0,"tx_queue_size":{"min":0,"max":3,"avg":1,"value_sum":6,"value_count":4},"tx_callback_ms":{"min":0,"max":2,"avg":1,"value_sum":4,"value_count":4},"tx_object_duration_us":{"min":100,"max":500,"avg":250,"value_sum":1000,"value_count":4}}}
+{"type":"publish","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"remote_endpoint_id":"client-42","track_namespace":"media/live/event1","track_name":"video","bytes_published":16384,"objects_published":64,"objects_dropped_not_ok":0,"quic":{"tx_buffer_drops":0,"tx_queue_discards":0,"tx_queue_expired":0,"tx_delayed_callback":0,"tx_reset_wait":0,"tx_queue_size":{"min":0,"max":3,"avg":1,"value_sum":6,"value_count":4},"tx_callback_ms":{"min":0,"max":2,"avg":1,"value_sum":4,"value_count":4},"tx_object_duration_us":{"min":100,"max":500,"avg":250,"value_sum":1000,"value_count":4}}}
 ```
 
 Publish-specific fields:
 
 | Field | Description |
 | --- | --- |
+| `remote_endpoint_id` | Remote endpoint ID from the publishing client's `CLIENT_SETUP`. Empty until setup is received. |
 | `track_namespace` | Namespace of the published content track. |
 | `track_name` | Name of the published content track. |
 | `bytes_published` | Payload bytes published during the sample period. |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -4,11 +4,13 @@ LAPS publishes relay metrics over MoQ tracks as newline-delimited JSON. Metrics 
 
 ## Transport
 
-The metrics publisher starts when the relay starts and stops with the relay. Each `MetricsSampled()` callback serializes the sample to one JSON object plus a trailing newline and pushes it into a `quicr::SafeQueue`. The metrics thread blocks on that queue and publishes each JSON line with `PublishTrack`.
+The metrics publisher starts when the relay starts and stops with the relay. Each `MetricsSampled()` callback serializes the sample to one JSON object plus a trailing newline and pushes it into a `quicr::SafeQueue`. The metrics thread blocks on that queue and publishes each JSON line through relay-local publish tracks.
 
 The queue is bounded. If the queue is full, the oldest queued sample is dropped and the new sample is kept.
 
-Metrics are published as MoQ objects using datagram track mode. Object IDs increase per metrics track, with `group_id` set to `0`.
+The relay registers the metrics tracks as self-published tracks using connection handle `0`; it does not publish metrics back through the client connection that emitted the sample. Normal `SUBSCRIBE` and `SUBSCRIBE_TRACKS` matching then forwards metrics objects to interested subscribers the same way it forwards objects from other publishers.
+
+Metrics are forwarded as MoQ objects using datagram track mode. Object IDs increase per metrics track, with `group_id` set to `0`.
 
 ## Tracks
 
@@ -184,4 +186,3 @@ Publish `quic` fields:
 | `tx_object_duration_us` | Object time in queue in microseconds. |
 
 `tx_queue_size`, `tx_callback_ms`, and `tx_object_duration_us` use the min/max/average object shape.
-

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -97,7 +97,7 @@ Connection metrics are emitted on the schema track with `type` set to `connectio
 Example:
 
 ```json
-{"type":"connection","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"remote_endpoint_id":"client-42","remote_ip":"192.0.2.44","remote_port":54431,"publish_tracks":3,"rx_dgram_unknown_track_alias":0,"rx_dgram_invalid_type":0,"rx_dgram_decode_failed":0,"rx_stream_buffer_error":0,"rx_stream_unknown_track_alias":0,"rx_stream_invalid_type":0,"invalid_ctrl_stream_msg":0,"quic":{"cwin_congested":0,"prev_cwin_congested":0,"tx_congested":0,"tx_rate_bps":{"min":1000,"max":2000,"avg":1500,"value_sum":3000,"value_count":2},"rx_rate_bps":{"min":900,"max":1800,"avg":1350,"value_sum":2700,"value_count":2},"tx_cwin_bytes":{"min":12000,"max":16000,"avg":14000,"value_sum":28000,"value_count":2},"tx_in_transit_bytes":{"min":0,"max":8000,"avg":4000,"value_sum":8000,"value_count":2},"rtt_us":{"min":1000,"max":1400,"avg":1200,"value_sum":2400,"value_count":2},"srtt_us":{"min":1100,"max":1300,"avg":1200,"value_sum":2400,"value_count":2},"tx_retransmits":0,"tx_lost_pkts":0,"tx_timer_losses":0,"tx_spurious_losses":0,"rx_dgrams":12,"rx_dgrams_bytes":4096,"tx_dgram_cb":15,"tx_dgram_ack":14,"tx_dgram_lost":0,"tx_dgram_spurious":0,"tx_dgram_drops":0}}
+{"type":"connection","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"remote_endpoint_id":"client-42","remote_ip":"192.0.2.44","remote_port":54431,"publish_tracks":3,"subscribe_tracks":5,"rx_dgram_unknown_track_alias":0,"rx_dgram_invalid_type":0,"rx_dgram_decode_failed":0,"rx_stream_buffer_error":0,"rx_stream_unknown_track_alias":0,"rx_stream_invalid_type":0,"invalid_ctrl_stream_msg":0,"quic":{"cwin_congested":0,"prev_cwin_congested":0,"tx_congested":0,"tx_rate_bps":{"min":1000,"max":2000,"avg":1500,"value_sum":3000,"value_count":2},"rx_rate_bps":{"min":900,"max":1800,"avg":1350,"value_sum":2700,"value_count":2},"tx_cwin_bytes":{"min":12000,"max":16000,"avg":14000,"value_sum":28000,"value_count":2},"tx_in_transit_bytes":{"min":0,"max":8000,"avg":4000,"value_sum":8000,"value_count":2},"rtt_us":{"min":1000,"max":1400,"avg":1200,"value_sum":2400,"value_count":2},"srtt_us":{"min":1100,"max":1300,"avg":1200,"value_sum":2400,"value_count":2},"tx_retransmits":0,"tx_lost_pkts":0,"tx_timer_losses":0,"tx_spurious_losses":0,"rx_dgrams":12,"rx_dgrams_bytes":4096,"tx_dgram_cb":15,"tx_dgram_ack":14,"tx_dgram_lost":0,"tx_dgram_spurious":0,"tx_dgram_drops":0}}
 ```
 
 Connection-specific fields:
@@ -107,7 +107,8 @@ Connection-specific fields:
 | `remote_endpoint_id` | Remote endpoint ID from the client's `CLIENT_SETUP`. Empty until setup is received. |
 | `remote_ip` | Remote client IP address recorded when the connection was accepted. Empty if unavailable. |
 | `remote_port` | Remote client UDP port recorded when the connection was accepted. `0` if unavailable. |
-| `publish_tracks` | Number of active publish tracks for this connection. |
+| `publish_tracks` | Number of tracks this connection publishes, counted from the subscribes the relay has made to the connection. |
+| `subscribe_tracks` | Number of subscribes the relay has received from this connection. A namespace subscribe contributes one per track it currently matches, not one per namespace. |
 | `rx_dgram_unknown_track_alias` | Datagrams received for an unknown track alias. |
 | `rx_dgram_invalid_type` | Datagrams with an invalid object datagram type. |
 | `rx_dgram_decode_failed` | Datagrams that failed to decode. |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -39,8 +39,10 @@ The track name identifies the OpenAPI schema used by every JSON line. The metric
 | `type` | Source callback |
 | --- | --- |
 | `connection` | `ClientManager::MetricsSampled(connection_handle, ConnectionMetrics)` |
-| `subscribe` | `SubscribeTrackHandler::MetricsSampled(SubscribeTrackMetrics)` |
-| `publish` | `PublishTrackHandler::MetricsSampled(PublishTrackMetrics)` |
+| `subscribe` | `PublishTrackHandler::MetricsSampled(PublishTrackMetrics)` |
+| `publish` | `SubscribeTrackHandler::MetricsSampled(SubscribeTrackMetrics)` |
+
+The `type` names the remote role the sample describes, which is the inverse of the relay-side handler that produced it. The relay runs a publish track in order to send to a subscriber, so those samples are typed `subscribe`. The relay runs a subscribe track in order to receive from a publisher, so those samples are typed `publish`.
 
 For example, with relay ID `relay-a`, consumers can subscribe to:
 
@@ -63,6 +65,8 @@ All metrics JSON objects include:
 | `connection_handle` | unsigned integer | libquicr connection handle associated with the sample. |
 
 All integer values are emitted as JSON numbers.
+
+`connection_handle` and `remote_endpoint_id` are tags: every sample of every type carries both, and together they identify the remote peer the sample is about. `relay_id`, `track_namespace`, and `track_name` are tags as well. The remaining fields are measurements for the sample period.
 
 ## Min/Max/Average Objects
 
@@ -142,47 +146,27 @@ Connection `quic` fields:
 
 ## Subscribe Metrics
 
-Subscribe metrics are emitted on the schema track with `type` set to `subscribe`.
+Subscribe metrics are emitted on the schema track with `type` set to `subscribe`. They are sampled on the relay publish track that sends to the subscriber, so one sample is produced per subscriber connection per track.
 
 Example:
 
 ```json
-{"type":"subscribe","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"track_namespace":"media/live/event1","track_name":"video","bytes_received":8192,"objects_received":32}
+{"type":"subscribe","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"remote_endpoint_id":"client-42","track_namespace":"media/live/event1","track_name":"video","bytes":16384,"objects":64,"objects_dropped_not_ok":0,"quic":{"tx_buffer_drops":0,"tx_queue_discards":0,"tx_queue_expired":0,"tx_delayed_callback":0,"tx_reset_wait":0,"tx_queue_size":{"min":0,"max":3,"avg":1,"value_sum":6,"value_count":4},"tx_callback_ms":{"min":0,"max":2,"avg":1,"value_sum":4,"value_count":4},"tx_object_duration_us":{"min":100,"max":500,"avg":250,"value_sum":1000,"value_count":4}}}
 ```
 
 Subscribe-specific fields:
 
 | Field | Description |
 | --- | --- |
-| `track_namespace` | Namespace of the subscribed content track. |
-| `track_name` | Name of the subscribed content track. |
-| `bytes_received` | Payload bytes received during the sample period. |
-| `objects_received` | Objects received during the sample period. |
-
-## Publish Metrics
-
-Publish metrics are emitted on the schema track with `type` set to `publish`.
-
-Example:
-
-```json
-{"type":"publish","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"remote_endpoint_id":"client-42","track_namespace":"media/live/event1","track_name":"video","bytes_published":16384,"objects_published":64,"objects_dropped_not_ok":0,"subscribers":4,"quic":{"tx_buffer_drops":0,"tx_queue_discards":0,"tx_queue_expired":0,"tx_delayed_callback":0,"tx_reset_wait":0,"tx_queue_size":{"min":0,"max":3,"avg":1,"value_sum":6,"value_count":4},"tx_callback_ms":{"min":0,"max":2,"avg":1,"value_sum":4,"value_count":4},"tx_object_duration_us":{"min":100,"max":500,"avg":250,"value_sum":1000,"value_count":4}}}
-```
-
-Publish-specific fields:
-
-| Field | Description |
-| --- | --- |
-| `remote_endpoint_id` | Remote endpoint ID from the publishing client's `CLIENT_SETUP`. Empty until setup is received. |
-| `track_namespace` | Namespace of the published content track. |
-| `track_name` | Name of the published content track. |
-| `bytes_published` | Payload bytes published during the sample period. |
-| `objects_published` | Objects published during the sample period. |
+| `remote_endpoint_id` | Remote endpoint ID from the subscribing client's `CLIENT_SETUP`. Empty until setup is received. |
+| `track_namespace` | Namespace of the content track. |
+| `track_name` | Name of the content track. |
+| `bytes` | Payload bytes sent to the subscriber during the sample period. |
+| `objects` | Objects sent to the subscriber during the sample period. |
 | `objects_dropped_not_ok` | Objects dropped because the publish handler was not in a publishable state. |
-| `subscribers` | Current number of local fanout subscribers for the track. Track-level, so every publish sample for the same track in a period carries the same value. Subscribers matched through a subscribe namespace are not counted. |
 | `quic` | QUIC data-context metrics object. |
 
-Publish `quic` fields:
+Subscribe `quic` fields:
 
 | Field | Description |
 | --- | --- |
@@ -196,3 +180,24 @@ Publish `quic` fields:
 | `tx_object_duration_us` | Object time in queue in microseconds. |
 
 `tx_queue_size`, `tx_callback_ms`, and `tx_object_duration_us` use the min/max/average object shape.
+
+## Publish Metrics
+
+Publish metrics are emitted on the schema track with `type` set to `publish`. They are sampled on the relay subscribe track that receives from the publisher, so one sample is produced per publisher connection per track.
+
+Example:
+
+```json
+{"type":"publish","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"remote_endpoint_id":"client-42","track_namespace":"media/live/event1","track_name":"video","bytes":8192,"objects":32,"subscribers":4}
+```
+
+Publish-specific fields:
+
+| Field | Description |
+| --- | --- |
+| `remote_endpoint_id` | Remote endpoint ID from the publishing client's `CLIENT_SETUP`. Empty until setup is received. |
+| `track_namespace` | Namespace of the content track. |
+| `track_name` | Name of the content track. |
+| `bytes` | Payload bytes received from the publisher during the sample period. |
+| `objects` | Objects received from the publisher during the sample period. |
+| `subscribers` | Current number of local fanout subscribers the relay is serving from this publisher's track. Subscribers matched through a subscribe namespace are not counted. |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -1,0 +1,187 @@
+# LAPS Metrics
+
+LAPS publishes relay metrics over MoQ tracks as newline-delimited JSON. Metrics are sampled by libquicr callbacks and queued for a relay-owned metrics publishing thread, so the callback path does not publish directly.
+
+## Transport
+
+The metrics publisher starts when the relay starts and stops with the relay. Each `MetricsSampled()` callback serializes the sample to one JSON object plus a trailing newline and pushes it into a `quicr::SafeQueue`. The metrics thread blocks on that queue and publishes each JSON line with `PublishTrack`.
+
+The queue is bounded. If the queue is full, the oldest queued sample is dropped and the new sample is kept.
+
+Metrics are published as MoQ objects using datagram track mode. Object IDs increase per metrics track, with `group_id` set to `0`.
+
+## Tracks
+
+The default metrics namespace is:
+
+```text
+metrics/<relay id>
+```
+
+The namespace can be overridden at startup:
+
+```text
+lapsRelay --metrics_namespace custom/metrics/namespace
+```
+
+The relay logs the namespace on startup. Slash-separated namespace strings are converted to MoQ namespace tuple entries.
+
+Each metrics type is published on a separate track name under the metrics namespace:
+
+| Track name | Source callback |
+| --- | --- |
+| `connection` | `ClientManager::MetricsSampled(connection_handle, ConnectionMetrics)` |
+| `subscribe` | `SubscribeTrackHandler::MetricsSampled(SubscribeTrackMetrics)` |
+| `publish` | `PublishTrackHandler::MetricsSampled(PublishTrackMetrics)` |
+
+For example, with relay ID `relay-a`, consumers can subscribe to:
+
+```text
+namespace: metrics/relay-a
+name: connection
+```
+
+## Common Fields
+
+All metrics JSON objects include:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | string | Metrics type: `connection`, `subscribe`, or `publish`. |
+| `relay_id` | string | Relay endpoint ID. |
+| `sample_time_us` | unsigned integer | Sample timestamp in microseconds since Unix epoch. |
+| `connection_handle` | unsigned integer | libquicr connection handle associated with the sample. |
+
+All integer values are emitted as JSON numbers.
+
+## Min/Max/Average Objects
+
+Several QUIC fields use the same min/max/average shape:
+
+```json
+{
+  "min": 100,
+  "max": 300,
+  "avg": 180,
+  "value_sum": 900,
+  "value_count": 5
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `min` | Minimum observed value in the sample period. |
+| `max` | Maximum observed value in the sample period. |
+| `avg` | Average value in the sample period. |
+| `value_sum` | Sum of all observed values in the sample period. |
+| `value_count` | Number of values included in the sample period. |
+
+## Connection Metrics
+
+Connection metrics are emitted on track name `connection`.
+
+Example:
+
+```json
+{"type":"connection","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"remote_ip":"192.0.2.44","remote_port":54431,"publish_tracks":3,"rx_dgram_unknown_track_alias":0,"rx_dgram_invalid_type":0,"rx_dgram_decode_failed":0,"rx_stream_buffer_error":0,"rx_stream_unknown_track_alias":0,"rx_stream_invalid_type":0,"invalid_ctrl_stream_msg":0,"quic":{"cwin_congested":0,"prev_cwin_congested":0,"tx_congested":0,"tx_rate_bps":{"min":1000,"max":2000,"avg":1500,"value_sum":3000,"value_count":2},"rx_rate_bps":{"min":900,"max":1800,"avg":1350,"value_sum":2700,"value_count":2},"tx_cwin_bytes":{"min":12000,"max":16000,"avg":14000,"value_sum":28000,"value_count":2},"tx_in_transit_bytes":{"min":0,"max":8000,"avg":4000,"value_sum":8000,"value_count":2},"rtt_us":{"min":1000,"max":1400,"avg":1200,"value_sum":2400,"value_count":2},"srtt_us":{"min":1100,"max":1300,"avg":1200,"value_sum":2400,"value_count":2},"tx_retransmits":0,"tx_lost_pkts":0,"tx_timer_losses":0,"tx_spurious_losses":0,"rx_dgrams":12,"rx_dgrams_bytes":4096,"tx_dgram_cb":15,"tx_dgram_ack":14,"tx_dgram_lost":0,"tx_dgram_spurious":0,"tx_dgram_drops":0}}
+```
+
+Connection-specific fields:
+
+| Field | Description |
+| --- | --- |
+| `remote_ip` | Remote client IP address recorded when the connection was accepted. Empty if unavailable. |
+| `remote_port` | Remote client UDP port recorded when the connection was accepted. `0` if unavailable. |
+| `publish_tracks` | Number of active publish tracks for this connection. |
+| `rx_dgram_unknown_track_alias` | Datagrams received for an unknown track alias. |
+| `rx_dgram_invalid_type` | Datagrams with an invalid object datagram type. |
+| `rx_dgram_decode_failed` | Datagrams that failed to decode. |
+| `rx_stream_buffer_error` | Stream buffer errors while parsing received stream data. |
+| `rx_stream_unknown_track_alias` | Stream data received for an unknown track alias. |
+| `rx_stream_invalid_type` | Stream data with an invalid message type. |
+| `invalid_ctrl_stream_msg` | Invalid control stream messages. This should normally be `0`. |
+| `quic` | QUIC connection metrics object. |
+
+Connection `quic` fields:
+
+| Field | Description |
+| --- | --- |
+| `cwin_congested` | Count of times congestion window was low or zero. |
+| `prev_cwin_congested` | Previous congestion-window congestion count. |
+| `tx_congested` | Count of times transmit path was considered congested. |
+| `tx_rate_bps` | Transmit rate in bits per second. |
+| `rx_rate_bps` | Receive rate estimate in bits per second. |
+| `tx_cwin_bytes` | Congestion window bytes. |
+| `tx_in_transit_bytes` | Bytes in transit. |
+| `rtt_us` | RTT in microseconds. |
+| `srtt_us` | Smoothed RTT in microseconds. |
+| `tx_retransmits` | Retransmission count. |
+| `tx_lost_pkts` | Lost packet count. |
+| `tx_timer_losses` | Packet losses detected by timer. |
+| `tx_spurious_losses` | Packets marked lost that were later acknowledged. |
+| `rx_dgrams` | Received datagram count. |
+| `rx_dgrams_bytes` | Received datagram bytes. |
+| `tx_dgram_cb` | Datagram send callback count. |
+| `tx_dgram_ack` | Acknowledged datagram callback count. |
+| `tx_dgram_lost` | Lost datagram callback count. |
+| `tx_dgram_spurious` | Late or delayed datagram acknowledgement count. |
+| `tx_dgram_drops` | Datagrams dropped because the data context was missing. |
+
+`tx_rate_bps`, `rx_rate_bps`, `tx_cwin_bytes`, `tx_in_transit_bytes`, `rtt_us`, and `srtt_us` use the min/max/average object shape.
+
+## Subscribe Metrics
+
+Subscribe metrics are emitted on track name `subscribe`.
+
+Example:
+
+```json
+{"type":"subscribe","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"track_namespace":"media/live/event1","track_name":"video","bytes_received":8192,"objects_received":32,"subscribers":4}
+```
+
+Subscribe-specific fields:
+
+| Field | Description |
+| --- | --- |
+| `track_namespace` | Namespace of the subscribed content track. |
+| `track_name` | Name of the subscribed content track. |
+| `bytes_received` | Payload bytes received during the sample period. |
+| `objects_received` | Objects received during the sample period. |
+| `subscribers` | Current number of local fanout subscribers for the track. |
+
+## Publish Metrics
+
+Publish metrics are emitted on track name `publish`.
+
+Example:
+
+```json
+{"type":"publish","relay_id":"relay-a","sample_time_us":1720000000000000,"connection_handle":10,"track_namespace":"media/live/event1","track_name":"video","bytes_published":16384,"objects_published":64,"objects_dropped_not_ok":0,"quic":{"tx_buffer_drops":0,"tx_queue_discards":0,"tx_queue_expired":0,"tx_delayed_callback":0,"tx_reset_wait":0,"tx_queue_size":{"min":0,"max":3,"avg":1,"value_sum":6,"value_count":4},"tx_callback_ms":{"min":0,"max":2,"avg":1,"value_sum":4,"value_count":4},"tx_object_duration_us":{"min":100,"max":500,"avg":250,"value_sum":1000,"value_count":4}}}
+```
+
+Publish-specific fields:
+
+| Field | Description |
+| --- | --- |
+| `track_namespace` | Namespace of the published content track. |
+| `track_name` | Name of the published content track. |
+| `bytes_published` | Payload bytes published during the sample period. |
+| `objects_published` | Objects published during the sample period. |
+| `objects_dropped_not_ok` | Objects dropped because the publish handler was not in a publishable state. |
+| `quic` | QUIC data-context metrics object. |
+
+Publish `quic` fields:
+
+| Field | Description |
+| --- | --- |
+| `tx_buffer_drops` | Write-buffer drops due to reset handling. |
+| `tx_queue_discards` | Objects discarded due to queue clearing or stream transition. |
+| `tx_queue_expired` | Objects expired before transmit. |
+| `tx_delayed_callback` | Count of delayed transmit callbacks. |
+| `tx_reset_wait` | Count of reset-and-wait events. |
+| `tx_queue_size` | Transmit queue size during the sample period. |
+| `tx_callback_ms` | Transmit callback duration in milliseconds. |
+| `tx_object_duration_us` | Object time in queue in microseconds. |
+
+`tx_queue_size`, `tx_callback_ms`, and `tx_object_duration_us` use the min/max/average object shape.
+

--- a/docs/metrics.openapi.yaml
+++ b/docs/metrics.openapi.yaml
@@ -91,7 +91,6 @@ components:
         - track_name
         - bytes_received
         - objects_received
-        - subscribers
       properties:
         type:
           type: string
@@ -110,8 +109,6 @@ components:
           $ref: '#/components/schemas/UnsignedInteger'
         objects_received:
           $ref: '#/components/schemas/UnsignedInteger'
-        subscribers:
-          $ref: '#/components/schemas/UnsignedInteger'
 
     PublishMetrics:
       type: object
@@ -127,6 +124,7 @@ components:
         - bytes_published
         - objects_published
         - objects_dropped_not_ok
+        - subscribers
         - quic
       properties:
         type:
@@ -149,6 +147,8 @@ components:
         objects_published:
           $ref: '#/components/schemas/UnsignedInteger'
         objects_dropped_not_ok:
+          $ref: '#/components/schemas/UnsignedInteger'
+        subscribers:
           $ref: '#/components/schemas/UnsignedInteger'
         quic:
           $ref: '#/components/schemas/PublishQuicMetrics'

--- a/docs/metrics.openapi.yaml
+++ b/docs/metrics.openapi.yaml
@@ -1,0 +1,269 @@
+openapi: 3.1.0
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
+info:
+  title: LAPS Metrics JSON Lines
+  version: 1.0.0
+  description: Schema for newline-delimited LAPS relay metrics published over MoQ.
+paths: {}
+x-moq:
+  namespace: metrics/<relay id>
+  track_name: laps.metrics.openapi.v1
+  content_type: application/x-ndjson
+components:
+  schemas:
+    MetricsSample:
+      description: One JSON object emitted as a line on the LAPS metrics MoQ track.
+      oneOf:
+        - $ref: '#/components/schemas/ConnectionMetrics'
+        - $ref: '#/components/schemas/SubscribeMetrics'
+        - $ref: '#/components/schemas/PublishMetrics'
+      discriminator:
+        propertyName: type
+        mapping:
+          connection: '#/components/schemas/ConnectionMetrics'
+          subscribe: '#/components/schemas/SubscribeMetrics'
+          publish: '#/components/schemas/PublishMetrics'
+
+    ConnectionMetrics:
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - relay_id
+        - sample_time_us
+        - connection_handle
+        - remote_ip
+        - remote_port
+        - publish_tracks
+        - rx_dgram_unknown_track_alias
+        - rx_dgram_invalid_type
+        - rx_dgram_decode_failed
+        - rx_stream_buffer_error
+        - rx_stream_unknown_track_alias
+        - rx_stream_invalid_type
+        - invalid_ctrl_stream_msg
+        - quic
+      properties:
+        type:
+          type: string
+          const: connection
+        relay_id:
+          type: string
+        sample_time_us:
+          $ref: '#/components/schemas/UnsignedInteger'
+        connection_handle:
+          $ref: '#/components/schemas/UnsignedInteger'
+        remote_ip:
+          type: string
+        remote_port:
+          $ref: '#/components/schemas/UnsignedInteger'
+        publish_tracks:
+          $ref: '#/components/schemas/UnsignedInteger'
+        rx_dgram_unknown_track_alias:
+          $ref: '#/components/schemas/UnsignedInteger'
+        rx_dgram_invalid_type:
+          $ref: '#/components/schemas/UnsignedInteger'
+        rx_dgram_decode_failed:
+          $ref: '#/components/schemas/UnsignedInteger'
+        rx_stream_buffer_error:
+          $ref: '#/components/schemas/UnsignedInteger'
+        rx_stream_unknown_track_alias:
+          $ref: '#/components/schemas/UnsignedInteger'
+        rx_stream_invalid_type:
+          $ref: '#/components/schemas/UnsignedInteger'
+        invalid_ctrl_stream_msg:
+          $ref: '#/components/schemas/UnsignedInteger'
+        quic:
+          $ref: '#/components/schemas/ConnectionQuicMetrics'
+
+    SubscribeMetrics:
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - relay_id
+        - sample_time_us
+        - connection_handle
+        - track_namespace
+        - track_name
+        - bytes_received
+        - objects_received
+        - subscribers
+      properties:
+        type:
+          type: string
+          const: subscribe
+        relay_id:
+          type: string
+        sample_time_us:
+          $ref: '#/components/schemas/UnsignedInteger'
+        connection_handle:
+          $ref: '#/components/schemas/UnsignedInteger'
+        track_namespace:
+          type: string
+        track_name:
+          type: string
+        bytes_received:
+          $ref: '#/components/schemas/UnsignedInteger'
+        objects_received:
+          $ref: '#/components/schemas/UnsignedInteger'
+        subscribers:
+          $ref: '#/components/schemas/UnsignedInteger'
+
+    PublishMetrics:
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - relay_id
+        - sample_time_us
+        - connection_handle
+        - track_namespace
+        - track_name
+        - bytes_published
+        - objects_published
+        - objects_dropped_not_ok
+        - quic
+      properties:
+        type:
+          type: string
+          const: publish
+        relay_id:
+          type: string
+        sample_time_us:
+          $ref: '#/components/schemas/UnsignedInteger'
+        connection_handle:
+          $ref: '#/components/schemas/UnsignedInteger'
+        track_namespace:
+          type: string
+        track_name:
+          type: string
+        bytes_published:
+          $ref: '#/components/schemas/UnsignedInteger'
+        objects_published:
+          $ref: '#/components/schemas/UnsignedInteger'
+        objects_dropped_not_ok:
+          $ref: '#/components/schemas/UnsignedInteger'
+        quic:
+          $ref: '#/components/schemas/PublishQuicMetrics'
+
+    ConnectionQuicMetrics:
+      type: object
+      additionalProperties: false
+      required:
+        - cwin_congested
+        - prev_cwin_congested
+        - tx_congested
+        - tx_rate_bps
+        - rx_rate_bps
+        - tx_cwin_bytes
+        - tx_in_transit_bytes
+        - rtt_us
+        - srtt_us
+        - tx_retransmits
+        - tx_lost_pkts
+        - tx_timer_losses
+        - tx_spurious_losses
+        - rx_dgrams
+        - rx_dgrams_bytes
+        - tx_dgram_cb
+        - tx_dgram_ack
+        - tx_dgram_lost
+        - tx_dgram_spurious
+        - tx_dgram_drops
+      properties:
+        cwin_congested:
+          $ref: '#/components/schemas/UnsignedInteger'
+        prev_cwin_congested:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_congested:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_rate_bps:
+          $ref: '#/components/schemas/MinMaxAvg'
+        rx_rate_bps:
+          $ref: '#/components/schemas/MinMaxAvg'
+        tx_cwin_bytes:
+          $ref: '#/components/schemas/MinMaxAvg'
+        tx_in_transit_bytes:
+          $ref: '#/components/schemas/MinMaxAvg'
+        rtt_us:
+          $ref: '#/components/schemas/MinMaxAvg'
+        srtt_us:
+          $ref: '#/components/schemas/MinMaxAvg'
+        tx_retransmits:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_lost_pkts:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_timer_losses:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_spurious_losses:
+          $ref: '#/components/schemas/UnsignedInteger'
+        rx_dgrams:
+          $ref: '#/components/schemas/UnsignedInteger'
+        rx_dgrams_bytes:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_dgram_cb:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_dgram_ack:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_dgram_lost:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_dgram_spurious:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_dgram_drops:
+          $ref: '#/components/schemas/UnsignedInteger'
+
+    PublishQuicMetrics:
+      type: object
+      additionalProperties: false
+      required:
+        - tx_buffer_drops
+        - tx_queue_discards
+        - tx_queue_expired
+        - tx_delayed_callback
+        - tx_reset_wait
+        - tx_queue_size
+        - tx_callback_ms
+        - tx_object_duration_us
+      properties:
+        tx_buffer_drops:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_queue_discards:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_queue_expired:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_delayed_callback:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_reset_wait:
+          $ref: '#/components/schemas/UnsignedInteger'
+        tx_queue_size:
+          $ref: '#/components/schemas/MinMaxAvg'
+        tx_callback_ms:
+          $ref: '#/components/schemas/MinMaxAvg'
+        tx_object_duration_us:
+          $ref: '#/components/schemas/MinMaxAvg'
+
+    MinMaxAvg:
+      type: object
+      additionalProperties: false
+      required:
+        - min
+        - max
+        - avg
+        - value_sum
+        - value_count
+      properties:
+        min:
+          $ref: '#/components/schemas/UnsignedInteger'
+        max:
+          $ref: '#/components/schemas/UnsignedInteger'
+        avg:
+          $ref: '#/components/schemas/UnsignedInteger'
+        value_sum:
+          $ref: '#/components/schemas/UnsignedInteger'
+        value_count:
+          $ref: '#/components/schemas/UnsignedInteger'
+
+    UnsignedInteger:
+      type: integer
+      minimum: 0

--- a/docs/metrics.openapi.yaml
+++ b/docs/metrics.openapi.yaml
@@ -32,6 +32,7 @@ components:
         - relay_id
         - sample_time_us
         - connection_handle
+        - remote_endpoint_id
         - remote_ip
         - remote_port
         - publish_tracks
@@ -53,6 +54,8 @@ components:
           $ref: '#/components/schemas/UnsignedInteger'
         connection_handle:
           $ref: '#/components/schemas/UnsignedInteger'
+        remote_endpoint_id:
+          type: string
         remote_ip:
           type: string
         remote_port:
@@ -118,6 +121,7 @@ components:
         - relay_id
         - sample_time_us
         - connection_handle
+        - remote_endpoint_id
         - track_namespace
         - track_name
         - bytes_published
@@ -134,6 +138,8 @@ components:
           $ref: '#/components/schemas/UnsignedInteger'
         connection_handle:
           $ref: '#/components/schemas/UnsignedInteger'
+        remote_endpoint_id:
+          type: string
         track_namespace:
           type: string
         track_name:

--- a/docs/metrics.openapi.yaml
+++ b/docs/metrics.openapi.yaml
@@ -36,6 +36,7 @@ components:
         - remote_ip
         - remote_port
         - publish_tracks
+        - subscribe_tracks
         - rx_dgram_unknown_track_alias
         - rx_dgram_invalid_type
         - rx_dgram_decode_failed
@@ -61,6 +62,8 @@ components:
         remote_port:
           $ref: '#/components/schemas/UnsignedInteger'
         publish_tracks:
+          $ref: '#/components/schemas/UnsignedInteger'
+        subscribe_tracks:
           $ref: '#/components/schemas/UnsignedInteger'
         rx_dgram_unknown_track_alias:
           $ref: '#/components/schemas/UnsignedInteger'

--- a/docs/metrics.openapi.yaml
+++ b/docs/metrics.openapi.yaml
@@ -80,37 +80,9 @@ components:
           $ref: '#/components/schemas/ConnectionQuicMetrics'
 
     SubscribeMetrics:
-      type: object
-      additionalProperties: false
-      required:
-        - type
-        - relay_id
-        - sample_time_us
-        - connection_handle
-        - track_namespace
-        - track_name
-        - bytes_received
-        - objects_received
-      properties:
-        type:
-          type: string
-          const: subscribe
-        relay_id:
-          type: string
-        sample_time_us:
-          $ref: '#/components/schemas/UnsignedInteger'
-        connection_handle:
-          $ref: '#/components/schemas/UnsignedInteger'
-        track_namespace:
-          type: string
-        track_name:
-          type: string
-        bytes_received:
-          $ref: '#/components/schemas/UnsignedInteger'
-        objects_received:
-          $ref: '#/components/schemas/UnsignedInteger'
-
-    PublishMetrics:
+      description: >-
+        Sampled on the relay publish track that sends to a subscriber, so the sample describes a
+        subscriber of the relay.
       type: object
       additionalProperties: false
       required:
@@ -121,11 +93,52 @@ components:
         - remote_endpoint_id
         - track_namespace
         - track_name
-        - bytes_published
-        - objects_published
+        - bytes
+        - objects
         - objects_dropped_not_ok
-        - subscribers
         - quic
+      properties:
+        type:
+          type: string
+          const: subscribe
+        relay_id:
+          type: string
+        sample_time_us:
+          $ref: '#/components/schemas/UnsignedInteger'
+        connection_handle:
+          $ref: '#/components/schemas/UnsignedInteger'
+        remote_endpoint_id:
+          type: string
+        track_namespace:
+          type: string
+        track_name:
+          type: string
+        bytes:
+          $ref: '#/components/schemas/UnsignedInteger'
+        objects:
+          $ref: '#/components/schemas/UnsignedInteger'
+        objects_dropped_not_ok:
+          $ref: '#/components/schemas/UnsignedInteger'
+        quic:
+          $ref: '#/components/schemas/SubscribeQuicMetrics'
+
+    PublishMetrics:
+      description: >-
+        Sampled on the relay subscribe track that receives from a publisher, so the sample describes a
+        publisher to the relay.
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - relay_id
+        - sample_time_us
+        - connection_handle
+        - remote_endpoint_id
+        - track_namespace
+        - track_name
+        - bytes
+        - objects
+        - subscribers
       properties:
         type:
           type: string
@@ -142,16 +155,12 @@ components:
           type: string
         track_name:
           type: string
-        bytes_published:
+        bytes:
           $ref: '#/components/schemas/UnsignedInteger'
-        objects_published:
-          $ref: '#/components/schemas/UnsignedInteger'
-        objects_dropped_not_ok:
+        objects:
           $ref: '#/components/schemas/UnsignedInteger'
         subscribers:
           $ref: '#/components/schemas/UnsignedInteger'
-        quic:
-          $ref: '#/components/schemas/PublishQuicMetrics'
 
     ConnectionQuicMetrics:
       type: object
@@ -219,7 +228,7 @@ components:
         tx_dgram_drops:
           $ref: '#/components/schemas/UnsignedInteger'
 
-    PublishQuicMetrics:
+    SubscribeQuicMetrics:
       type: object
       additionalProperties: false
       required:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(lapsRelay
         main.cc
         config.cc
         client_manager.cc
+        metrics_publisher.cc
         subscribe_handler.cc
         publish_handler.cc
         fetch_handler.cc

--- a/src/client_manager.cc
+++ b/src/client_manager.cc
@@ -37,12 +37,14 @@ namespace laps {
 
     quicr::Session::Status ClientManager::Start()
     {
-        const auto status = quicr::Session::Start();
-        if (status == quicr::Session::Status::kReady) {
-            metrics_publisher_.Start();
-        }
+        /*
+         * Set up relay-local metrics track state before starting the transport thread. Session::Start()
+         * spins up the transport thread that dispatches all control/data callbacks; starting metrics
+         * publishing first avoids any chance of racing with that thread while touching ClientManager state.
+         */
+        metrics_publisher_.Start();
 
-        return status;
+        return quicr::Session::Start();
     }
 
     void ClientManager::Stop()
@@ -281,7 +283,27 @@ namespace laps {
                                         const quicr::PublishAttributes& publish_attributes,
                                         [[maybe_unused]] std::weak_ptr<quicr::SubscribeNamespaceHandler> sub_ns_handler)
     {
-        bool is_from_peer = !connection_handle && !request_id;
+        PublishReceivedInternal(connection_handle, request_id, publish_attributes, !connection_handle && !request_id);
+    }
+
+    void ClientManager::RegisterLocalPublish(const quicr::PublishAttributes& publish_attributes)
+    {
+        PublishReceivedInternal(0, 0, publish_attributes, false);
+    }
+
+    void ClientManager::PublishReceivedInternal(std::uint64_t connection_handle,
+                                                uint64_t request_id,
+                                                const quicr::PublishAttributes& publish_attributes,
+                                                bool is_from_peer)
+    {
+        /*
+         * Peer-originated publishes and relay-local publishes (e.g. the metrics track) both use the
+         * connection_handle=0/request_id=0 sentinel because there is no real connection to resolve the
+         * publish response against. Track alias assignment and ResolvePublish()/ClientAnnounce() must be
+         * bypassed for both, independent of whether the publish is actually from-peer.
+         */
+        const bool bypass_resolve = !connection_handle && !request_id;
+
         auto th = quicr::TrackHash(publish_attributes.track_full_name);
 
         SPDLOG_LOGGER_INFO(
@@ -339,9 +361,13 @@ namespace laps {
                                                                          config_.tick_service_,
                                                                          true);
 
-        if (is_from_peer) {
-            // For peering, need to set the track alias
+        if (bypass_resolve) {
+            // ResolvePublish() normally sets the track alias against a real connection; set it explicitly
+            // since that call is skipped below.
             sub_track_handler->SetTrackAlias(publish_attributes.track_alias);
+        }
+
+        if (is_from_peer) {
             sub_track_handler->SetFromPeer();
         }
 
@@ -351,7 +377,7 @@ namespace laps {
 
         state_.pub_subscribes[{ th.track_fullname_hash, connection_handle }] = sub_track_handler;
 
-        if (!is_from_peer) {
+        if (!bypass_resolve) {
             state_.pub_subscribes_by_req_id[{ request_id, connection_handle }] = sub_track_handler;
 
             // Do this before pause to maintain MOQT message sequence order

--- a/src/client_manager.cc
+++ b/src/client_manager.cc
@@ -25,12 +25,36 @@ namespace laps {
       , state_(state)
       , config_(config)
       , peer_manager_(peer_manager)
+      , metrics_publisher_(*this, config)
       , cache_duration_ms_(cache_duration_ms)
     {
     }
 
+    ClientManager::~ClientManager()
+    {
+        metrics_publisher_.Stop();
+    }
+
+    quicr::Session::Status ClientManager::Start()
+    {
+        const auto status = quicr::Session::Start();
+        if (status == quicr::Session::Status::kReady) {
+            metrics_publisher_.Start();
+        }
+
+        return status;
+    }
+
+    void ClientManager::Stop()
+    {
+        metrics_publisher_.Stop();
+        quicr::Session::Stop();
+    }
+
     void ClientManager::NewConnectionAccepted(std::uint64_t connection_handle, const ConnectionRemoteInfo& remote)
     {
+        metrics_publisher_.AddConnection(connection_handle, remote);
+
         SPDLOG_LOGGER_INFO(
           LOGGER, "New connection handle {0} accepted from {1}:{2}", connection_handle, remote.ip, remote.port);
     }
@@ -552,6 +576,8 @@ namespace laps {
                 SPDLOG_LOGGER_DEBUG(LOGGER, "Connection idle timeout; connection_handle: {0} ", connection_handle);
                 break;
         }
+
+        metrics_publisher_.RemoveConnection(connection_handle);
 
         // Remove all subscribe announces for this connection handle
         std::vector<quicr::TrackNamespace> remove_ns;
@@ -1255,7 +1281,8 @@ namespace laps {
                                attrs.priority,
                                th.track_namespace_hash,
                                th.track_name_hash,
-                               attrs.new_group_request_id ? std::to_string(*attrs.new_group_request_id) : std::string("none"),
+                               attrs.new_group_request_id ? std::to_string(*attrs.new_group_request_id)
+                                                          : std::string("none"),
                                start_location.group,
                                start_location.object);
 
@@ -1400,6 +1427,7 @@ namespace laps {
     void ClientManager::MetricsSampled(const std::uint64_t connection_handle, const quicr::ConnectionMetrics& metrics)
     {
         const auto publish_track_count = state_.PublishTrackCount(connection_handle);
+        metrics_publisher_.QueueConnectionMetrics(connection_handle, publish_track_count, metrics);
 
         SPDLOG_LOGGER_DEBUG(LOGGER,
                             "Metrics connection handle: {}"

--- a/src/client_manager.cc
+++ b/src/client_manager.cc
@@ -1397,6 +1397,19 @@ namespace laps {
         }
     }
 
+    bool ClientManager::PublishLocalObject(std::uint64_t track_fullname_hash,
+                                           const quicr::ObjectHeaders& object_headers,
+                                           quicr::BytesSpan data)
+    {
+        const auto it = state_.pub_subscribes.find({ track_fullname_hash, 0 });
+        if (it == state_.pub_subscribes.end() || !it->second) {
+            return false;
+        }
+
+        it->second->ObjectReceived(object_headers, data);
+        return true;
+    }
+
     void ClientManager::PeerDataReceived(std::uint64_t track_full_name_hash,
                                          bool is_new_stream,
                                          std::optional<uint64_t> stream_id,
@@ -1428,19 +1441,5 @@ namespace laps {
     {
         const auto publish_track_count = state_.PublishTrackCount(connection_handle);
         metrics_publisher_.QueueConnectionMetrics(connection_handle, publish_track_count, metrics);
-
-        SPDLOG_LOGGER_DEBUG(LOGGER,
-                            "Metrics connection handle: {}"
-                            " rtt_us: {}"
-                            " srtt_us: {}"
-                            " rate_bps: {}"
-                            " lost pkts: {}"
-                            " publish tracks: {}",
-                            connection_handle,
-                            metrics.quic.rtt_us.max,
-                            metrics.quic.srtt_us.max,
-                            metrics.quic.tx_rate_bps.max,
-                            metrics.quic.tx_lost_pkts,
-                            publish_track_count);
     }
 }

--- a/src/client_manager.cc
+++ b/src/client_manager.cc
@@ -433,6 +433,8 @@ namespace laps {
 
             sub_track_handler->Pause();
         }
+
+        state_.conn_state_metrics[connection_handle].published_tracks++;
     }
 
     void ClientManager::SubscribeTracksReceived(std::uint64_t connection_handle,
@@ -682,11 +684,16 @@ namespace laps {
             break;
         }
 
+        auto& metrics_pub_tarcks = state_.conn_state_metrics[connection_handle].published_tracks;
+        if (metrics_pub_tarcks > 0) {
+            metrics_pub_tarcks--;
+        }
+
         std::vector<std::pair<std::uint64_t, std::uint64_t>> unsub_list;
 
         if (!have_publishers) {
 
-            // TODO: check if subscyyribe requests detatch or not
+            // TODO: check if subscribe requests detatch or not
 
             if (!config_.detached_subs) {
                 // Find subscribers that match this publisher and unsubscribe
@@ -740,6 +747,11 @@ namespace laps {
                                 connection_handle,
                                 request_id);
             return;
+        }
+
+        auto& metric_sub_count = state_.conn_state_metrics[connection_handle].subscribed_tracks;
+        if (metric_sub_count > 0) {
+            --metric_sub_count;
         }
 
         state_.subscribe_alias_req_id.erase(ta_it);
@@ -1315,6 +1327,8 @@ namespace laps {
                                start_location.group,
                                start_location.object);
 
+            state_.conn_state_metrics[connection_handle].subscribed_tracks++;
+
             // record subscribe as active from this subscriber
             state_.subscribe_active_[{ track_full_name.name_space, th.track_name_hash }].emplace(
               State::SubscribeInfo{ connection_handle,
@@ -1476,6 +1490,8 @@ namespace laps {
     void ClientManager::MetricsSampled(const std::uint64_t connection_handle, const quicr::ConnectionMetrics& metrics)
     {
         const auto publish_track_count = state_.PublishTrackCount(connection_handle);
-        metrics_publisher_.QueueConnectionMetrics(connection_handle, publish_track_count, metrics);
+        const auto subscribe_track_count = state_.SubscribeTrackCount(connection_handle);
+        metrics_publisher_.QueueConnectionMetrics(
+          connection_handle, publish_track_count, subscribe_track_count, metrics);
     }
 }

--- a/src/client_manager.cc
+++ b/src/client_manager.cc
@@ -1473,21 +1473,6 @@ namespace laps {
         it->second->StreamClosed(stream_id, reset);
     }
 
-    std::size_t ClientManager::TrackSubscriberCount(std::uint64_t track_fullname_hash)
-    {
-        std::size_t count = 0;
-
-        std::lock_guard _(state_.state_mutex);
-
-        for (const auto& [ta_conn, handler] : state_.pub_subscribes) {
-            if (ta_conn.first == track_fullname_hash && handler) {
-                count += handler->SubscriberCount();
-            }
-        }
-
-        return count;
-    }
-
     void ClientManager::MetricsSampled(const std::uint64_t connection_handle, const quicr::ConnectionMetrics& metrics)
     {
         const auto publish_track_count = state_.PublishTrackCount(connection_handle);

--- a/src/client_manager.cc
+++ b/src/client_manager.cc
@@ -1473,6 +1473,21 @@ namespace laps {
         it->second->StreamClosed(stream_id, reset);
     }
 
+    std::size_t ClientManager::TrackSubscriberCount(std::uint64_t track_fullname_hash)
+    {
+        std::size_t count = 0;
+
+        std::lock_guard _(state_.state_mutex);
+
+        for (const auto& [ta_conn, handler] : state_.pub_subscribes) {
+            if (ta_conn.first == track_fullname_hash && handler) {
+                count += handler->SubscriberCount();
+            }
+        }
+
+        return count;
+    }
+
     void ClientManager::MetricsSampled(const std::uint64_t connection_handle, const quicr::ConnectionMetrics& metrics)
     {
         const auto publish_track_count = state_.PublishTrackCount(connection_handle);

--- a/src/client_manager.cc
+++ b/src/client_manager.cc
@@ -638,8 +638,11 @@ namespace laps {
         PurgePublishState(connection_handle);
     }
 
-    void ClientManager::ClientSetupReceived(std::uint64_t, const quicr::ClientSetupAttributes& client_setup_attributes)
+    void ClientManager::ClientSetupReceived(std::uint64_t connection_handle,
+                                            const quicr::ClientSetupAttributes& client_setup_attributes)
     {
+        metrics_publisher_.SetConnectionEndpointId(connection_handle, client_setup_attributes.endpoint_id);
+
         SPDLOG_LOGGER_INFO(LOGGER, "Client setup received from endpoint_id: {0}", client_setup_attributes.endpoint_id);
     }
 

--- a/src/client_manager.h
+++ b/src/client_manager.h
@@ -155,15 +155,6 @@ namespace laps {
         void MetricsSampled(const std::uint64_t connection_handle, const quicr::ConnectionMetrics& metrics) override;
 
       private:
-        /**
-         * @brief Number of subscribers being served fanout of a track
-         *
-         * @param track_fullname_hash   Full track name hash of the track
-         *
-         * @return Sum of SUBSCRIBE fanout subscribers across every publisher subscribe for the track
-         */
-        std::size_t TrackSubscriberCount(std::uint64_t track_fullname_hash);
-
         void PublishReceivedInternal(std::uint64_t connection_handle,
                                      uint64_t request_id,
                                      const quicr::PublishAttributes& publish_attributes,

--- a/src/client_manager.h
+++ b/src/client_manager.h
@@ -117,6 +117,15 @@ namespace laps {
                              const quicr::PublishAttributes& publish_attributes,
                              std::weak_ptr<quicr::SubscribeNamespaceHandler> ns_handler) override;
 
+        /**
+         * @brief Register a relay-local publish (e.g. the internally generated metrics track)
+         *
+         * @details Unlike PublishReceived(), this is never treated as peer-originated even though it uses
+         *      the same connection_handle=0/request_id=0 sentinel internally. Use this instead of calling
+         *      PublishReceived(0, 0, ...) directly for relay-local publishes.
+         */
+        void RegisterLocalPublish(const quicr::PublishAttributes& publish_attributes);
+
         void ProcessSubscribe(std::uint64_t connection_handle,
                               uint64_t request_id,
                               const quicr::TrackHash& th,
@@ -145,6 +154,11 @@ namespace laps {
         void MetricsSampled(const std::uint64_t connection_handle, const quicr::ConnectionMetrics& metrics) override;
 
       private:
+        void PublishReceivedInternal(std::uint64_t connection_handle,
+                                     uint64_t request_id,
+                                     const quicr::PublishAttributes& publish_attributes,
+                                     bool is_from_peer);
+
         void PurgePublishState(std::uint64_t connection_handle);
 
         void FetchReceived(std::uint64_t connection_handle,

--- a/src/client_manager.h
+++ b/src/client_manager.h
@@ -6,7 +6,9 @@
 #include "track_ranking.h"
 #include <peering/peer_manager.h>
 #include <quicr/containers/cache.h>
+#include <quicr/messages/object.h>
 #include <quicr/session.h>
+#include <quicr/utilities/bytes.h>
 
 #include <functional>
 #include <set>
@@ -121,6 +123,10 @@ namespace laps {
                               const quicr::FullTrackName& track_full_name,
                               const quicr::SubscribeAttributes&,
                               std::optional<quicr::messages::Location>);
+
+        bool PublishLocalObject(std::uint64_t track_fullname_hash,
+                                const quicr::ObjectHeaders& object_headers,
+                                quicr::BytesSpan data);
 
         void PeerDataReceived(std::uint64_t track_full_name_hash,
                               bool is_new_stream,

--- a/src/client_manager.h
+++ b/src/client_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "metrics_publisher.h"
 #include "state.h"
 
 #include "track_ranking.h"
@@ -55,6 +56,10 @@ namespace laps {
                       const quicr::ServerConfig& cfg,
                       peering::PeerManager& peer_manager,
                       size_t cache_duration_ms = 60000);
+        ~ClientManager();
+
+        quicr::Session::Status Start() override;
+        void Stop() override;
 
         void NewConnectionAccepted(std::uint64_t connection_handle, const ConnectionRemoteInfo& remote) override;
 
@@ -147,6 +152,7 @@ namespace laps {
         State& state_;
         const Config& config_;
         peering::PeerManager& peer_manager_;
+        MetricsPublisher metrics_publisher_;
 
         /**
          * @brief Map of atomic bools to mark if a fetch thread should be interrupted.

--- a/src/client_manager.h
+++ b/src/client_manager.h
@@ -155,6 +155,15 @@ namespace laps {
         void MetricsSampled(const std::uint64_t connection_handle, const quicr::ConnectionMetrics& metrics) override;
 
       private:
+        /**
+         * @brief Number of subscribers being served fanout of a track
+         *
+         * @param track_fullname_hash   Full track name hash of the track
+         *
+         * @return Sum of SUBSCRIBE fanout subscribers across every publisher subscribe for the track
+         */
+        std::size_t TrackSubscriberCount(std::uint64_t track_fullname_hash);
+
         void PublishReceivedInternal(std::uint64_t connection_handle,
                                      uint64_t request_id,
                                      const quicr::PublishAttributes& publish_attributes,

--- a/src/client_manager.h
+++ b/src/client_manager.h
@@ -82,7 +82,8 @@ namespace laps {
 
         void ConnectionStatusChanged(std::uint64_t connection_handle, ConnectionStatus status) override;
 
-        void ClientSetupReceived(std::uint64_t, const quicr::ClientSetupAttributes& client_setup_attributes) override;
+        void ClientSetupReceived(std::uint64_t connection_handle,
+                                 const quicr::ClientSetupAttributes& client_setup_attributes) override;
 
         void UnsubscribeReceived(std::uint64_t connection_handle, uint64_t request_id) override;
         void PublishDoneReceived(std::uint64_t connection_handle, uint64_t request_id) override;

--- a/src/config.cc
+++ b/src/config.cc
@@ -22,6 +22,7 @@ namespace laps {
         char relay_id[200];
         gethostname(relay_id, sizeof(relay_id));
         relay_id_ = relay_id;
+        metrics_namespace_ = "metrics/" + relay_id_;
         object_ttl_ = kDefaultObjectTtl;
     }
 

--- a/src/config.h
+++ b/src/config.h
@@ -36,6 +36,7 @@ namespace laps {
         bool disable_cache{ false };
 
         std::string relay_id_;
+        std::string metrics_namespace_;
         std::string tls_cert_filename_;
         std::string tls_key_filename_;
         std::string qlog_path_;

--- a/src/main.cc
+++ b/src/main.cc
@@ -107,6 +107,8 @@ InitConfig(cxxopts::ParseResult& cli_opts, Config& cfg)
     cfg.sub_dampen_ms_ = cli_opts["sub_dampen_ms"].as<uint32_t>();
 
     cfg.relay_id_ = cli_opts["endpoint_id"].as<std::string>();
+    cfg.metrics_namespace_ = cli_opts.count("metrics_namespace") ? cli_opts["metrics_namespace"].as<std::string>()
+                                                                 : "metrics/" + cfg.relay_id_;
 
     if (cli_opts.count("cache_key")) {
         cfg.cache_key = cli_opts["cache_key"].as<std::uint64_t>();
@@ -159,6 +161,7 @@ main(int argc, char* argv[])
             "Duration of cache objects in milliseconds",
             cxxopts::value<size_t>()->default_value("60000"))
         ("cache_key", "Value of isCached extension key", cxxopts::value<std::uint64_t>())
+        ("metrics_namespace", "Metrics publish namespace", cxxopts::value<std::string>())
         ("l,detached_subs", "Enable support for detached subscribers")
         ("disable_cache", "Disable object caching")
         ("allow_self", "Allow subscribe namespace self-subscriptions");
@@ -186,6 +189,7 @@ main(int argc, char* argv[])
     std::unique_lock<std::mutex> lock(gvars::main_mutex);
 
     quicr::ServerConfig server_config = InitConfig(result, laps_config);
+    SPDLOG_LOGGER_INFO(laps_config.logger_, "Using metrics namespace: {}", laps_config.metrics_namespace_);
 
     std::shared_ptr<peering::InfoBase> forwarding_info = std::make_shared<peering::InfoBase>();
     peering::PeerManager peer_manager(laps_config, state, forwarding_info);

--- a/src/metrics_publisher.cc
+++ b/src/metrics_publisher.cc
@@ -309,6 +309,7 @@ namespace laps {
 
     void MetricsPublisher::QueuePublishMetrics(std::uint64_t connection_handle,
                                                const quicr::FullTrackName& track_name,
+                                               std::size_t subscriber_count,
                                                const quicr::PublishTrackMetrics& metrics)
     {
         const auto track_namespace = track_name.NamespaceStr();
@@ -326,6 +327,7 @@ namespace laps {
         AppendUintField(out, first, "bytes_published", metrics.bytes_published);
         AppendUintField(out, first, "objects_published", metrics.objects_published);
         AppendUintField(out, first, "objects_dropped_not_ok", metrics.objects_dropped_not_ok);
+        AppendUintField(out, first, "subscribers", static_cast<std::uint64_t>(subscriber_count));
         AppendRawField(out, first, "quic", SerializePublishQuic(metrics.quic));
         out << "}\n";
 
@@ -334,7 +336,6 @@ namespace laps {
 
     void MetricsPublisher::QueueSubscribeMetrics(std::uint64_t connection_handle,
                                                  const quicr::FullTrackName& track_name,
-                                                 std::size_t subscriber_count,
                                                  const quicr::SubscribeTrackMetrics& metrics)
     {
         const auto track_namespace = track_name.NamespaceStr();
@@ -349,7 +350,6 @@ namespace laps {
         AppendStringField(out, first, "track_name", name);
         AppendUintField(out, first, "bytes_received", metrics.bytes_received);
         AppendUintField(out, first, "objects_received", metrics.objects_received);
-        AppendUintField(out, first, "subscribers", static_cast<std::uint64_t>(subscriber_count));
         out << "}\n";
 
         QueueSample({ out.str() });

--- a/src/metrics_publisher.cc
+++ b/src/metrics_publisher.cc
@@ -393,7 +393,7 @@ namespace laps {
         headers.status = quicr::ObjectStatus::kAvailable;
         headers.priority = kDefaultPriority;
         headers.ttl = static_cast<std::uint16_t>(kDefaultObjectTtl);
-        headers.track_mode = quicr::TrackMode::kDatagram;
+        headers.track_mode = quicr::TrackMode::kStream;
 
         try {
             if (!server_.PublishLocalObject(target->track_fullname_hash, headers, payload)) {

--- a/src/metrics_publisher.cc
+++ b/src/metrics_publisher.cc
@@ -213,20 +213,30 @@ namespace laps {
         }
 
         EnsureMetricsTracks();
-        worker_ = std::thread(&MetricsPublisher::Run, this);
+        worker_ = std::thread(&MetricsPublisher::WorkerRun, this);
         SPDLOG_LOGGER_INFO(config_.logger_,
-                           "Metrics publishing enabled on namespace {} name {}",
+                           "Metrics publishing enabled on namespace {} name {} (batch interval {}ms)",
                            MetricsNamespaceStr(),
-                           kMetricsSchemaTrackName);
+                           kMetricsSchemaTrackName,
+                           kBatchInterval.count());
     }
 
     void MetricsPublisher::Stop()
     {
         const bool was_running = running_.exchange(false);
-        queue_.StopWaiting();
+        {
+            std::lock_guard<std::mutex> lock(worker_mutex_);
+            worker_cv_.notify_all();
+        }
 
         if (worker_.joinable()) {
             worker_.join();
+        }
+
+        queue_.Clear();
+        {
+            std::lock_guard<std::mutex> lock(pending_batch_mutex_);
+            pending_batch_.reset();
         }
 
         if (was_running) {
@@ -342,18 +352,63 @@ namespace laps {
             SPDLOG_LOGGER_DEBUG(config_.logger_, "Metrics queue full, dropped oldest sample");
         }
 
+        /*
+         * Queue*Metrics() (and therefore this) is only ever called from MetricsSampled() callbacks, which
+         * the relay's transport dispatches on its single control/data thread. Publishing a batch touches
+         * ClientManager state and libquicr handler internals that are only safe to touch from that same
+         * thread, so the actual publish must happen here rather than on worker_. This call is cheap: almost
+         * always there's no batch ready yet and it's just a mutex check.
+         */
+        FlushPendingBatch();
+
         return pushed;
     }
 
-    void MetricsPublisher::Run()
+    void MetricsPublisher::FlushPendingBatch()
     {
+        std::optional<MetricsSample> batch;
+        {
+            std::lock_guard<std::mutex> lock(pending_batch_mutex_);
+            batch.swap(pending_batch_);
+        }
+
+        if (batch.has_value()) {
+            PublishSample(*batch);
+        }
+    }
+
+    void MetricsPublisher::WorkerRun()
+    {
+        std::unique_lock<std::mutex> lock(worker_mutex_);
         while (running_) {
-            auto sample = queue_.BlockPop();
-            if (!sample.has_value()) {
+            worker_cv_.wait_for(lock, kBatchInterval);
+            if (!running_) {
                 break;
             }
 
-            PublishSample(*sample);
+            lock.unlock();
+
+            // Coalesce whatever has queued up since the last batch into a single JSON-lines payload. This is
+            // pure CPU work: it never touches ClientManager or libquicr handler state, so it's safe here.
+            std::string batched;
+            std::size_t count = 0;
+            while (auto sample = queue_.Pop()) {
+                batched += sample->json_line;
+                ++count;
+            }
+
+            if (count > 0) {
+                std::lock_guard<std::mutex> pending_lock(pending_batch_mutex_);
+                if (pending_batch_.has_value()) {
+                    pending_batch_->json_line += batched;
+                } else {
+                    pending_batch_ = MetricsSample{ std::move(batched) };
+                }
+
+                SPDLOG_LOGGER_DEBUG(config_.logger_, "Metrics batch ready: {} samples coalesced", count);
+            }
+
+            lock.lock();
         }
     }
 
@@ -440,7 +495,7 @@ namespace laps {
                                               std::nullopt,
                                               kDefaultObjectTtl,
                                               {} };
-        server_.PublishReceived(0, 0, attrs, {});
+        server_.RegisterLocalPublish(attrs);
 
         std::lock_guard<std::mutex> lock(tracks_mutex_);
         if (!metrics_track_.has_value()) {

--- a/src/metrics_publisher.cc
+++ b/src/metrics_publisher.cc
@@ -309,8 +309,33 @@ namespace laps {
 
     void MetricsPublisher::QueuePublishMetrics(std::uint64_t connection_handle,
                                                const quicr::FullTrackName& track_name,
-                                               std::size_t subscriber_count,
                                                const quicr::PublishTrackMetrics& metrics)
+    {
+        const auto track_namespace = track_name.NamespaceStr();
+        const auto name = track_name.NameStr();
+        const auto remote_info = LookupRemote(connection_handle);
+
+        std::ostringstream out;
+        bool first = true;
+        out << '{';
+        AppendCommonFields(
+          out, first, TypeName(MetricType::kSubscribe), config_.relay_id_, metrics.last_sample_time, connection_handle);
+        AppendStringField(out, first, "remote_endpoint_id", remote_info.endpoint_id);
+        AppendStringField(out, first, "track_namespace", track_namespace);
+        AppendStringField(out, first, "track_name", name);
+        AppendUintField(out, first, "bytes", metrics.bytes_published);
+        AppendUintField(out, first, "objects", metrics.objects_published);
+        AppendUintField(out, first, "objects_dropped_not_ok", metrics.objects_dropped_not_ok);
+        AppendRawField(out, first, "quic", SerializePublishQuic(metrics.quic));
+        out << "}\n";
+
+        QueueSample({ out.str() });
+    }
+
+    void MetricsPublisher::QueueSubscribeMetrics(std::uint64_t connection_handle,
+                                                 const quicr::FullTrackName& track_name,
+                                                 std::size_t subscriber_count,
+                                                 const quicr::SubscribeTrackMetrics& metrics)
     {
         const auto track_namespace = track_name.NamespaceStr();
         const auto name = track_name.NameStr();
@@ -324,32 +349,9 @@ namespace laps {
         AppendStringField(out, first, "remote_endpoint_id", remote_info.endpoint_id);
         AppendStringField(out, first, "track_namespace", track_namespace);
         AppendStringField(out, first, "track_name", name);
-        AppendUintField(out, first, "bytes_published", metrics.bytes_published);
-        AppendUintField(out, first, "objects_published", metrics.objects_published);
-        AppendUintField(out, first, "objects_dropped_not_ok", metrics.objects_dropped_not_ok);
+        AppendUintField(out, first, "bytes", metrics.bytes_received);
+        AppendUintField(out, first, "objects", metrics.objects_received);
         AppendUintField(out, first, "subscribers", static_cast<std::uint64_t>(subscriber_count));
-        AppendRawField(out, first, "quic", SerializePublishQuic(metrics.quic));
-        out << "}\n";
-
-        QueueSample({ out.str() });
-    }
-
-    void MetricsPublisher::QueueSubscribeMetrics(std::uint64_t connection_handle,
-                                                 const quicr::FullTrackName& track_name,
-                                                 const quicr::SubscribeTrackMetrics& metrics)
-    {
-        const auto track_namespace = track_name.NamespaceStr();
-        const auto name = track_name.NameStr();
-
-        std::ostringstream out;
-        bool first = true;
-        out << '{';
-        AppendCommonFields(
-          out, first, TypeName(MetricType::kSubscribe), config_.relay_id_, metrics.last_sample_time, connection_handle);
-        AppendStringField(out, first, "track_namespace", track_namespace);
-        AppendStringField(out, first, "track_name", name);
-        AppendUintField(out, first, "bytes_received", metrics.bytes_received);
-        AppendUintField(out, first, "objects_received", metrics.objects_received);
         out << "}\n";
 
         QueueSample({ out.str() });

--- a/src/metrics_publisher.cc
+++ b/src/metrics_publisher.cc
@@ -15,6 +15,8 @@
 
 namespace laps {
     namespace {
+        constexpr std::string_view kMetricsSchemaTrackName = "laps.metrics.openapi.v1";
+
         std::vector<std::string> SplitNamespace(const std::string& value, const std::string& relay_id)
         {
             const std::string namespace_value = value.empty() ? "metrics/" + relay_id : value;
@@ -212,7 +214,10 @@ namespace laps {
 
         EnsureMetricsTracks();
         worker_ = std::thread(&MetricsPublisher::Run, this);
-        SPDLOG_LOGGER_INFO(config_.logger_, "Metrics publishing enabled on namespace {}", MetricsNamespaceStr());
+        SPDLOG_LOGGER_INFO(config_.logger_,
+                           "Metrics publishing enabled on namespace {} name {}",
+                           MetricsNamespaceStr(),
+                           kMetricsSchemaTrackName);
     }
 
     void MetricsPublisher::Stop()
@@ -277,7 +282,7 @@ namespace laps {
         AppendRawField(out, first, "quic", SerializeConnectionQuic(metrics.quic));
         out << "}\n";
 
-        QueueSample({ MetricType::kConnection, connection_handle, out.str() });
+        QueueSample({ out.str() });
     }
 
     void MetricsPublisher::QueuePublishMetrics(std::uint64_t connection_handle,
@@ -300,7 +305,7 @@ namespace laps {
         AppendRawField(out, first, "quic", SerializePublishQuic(metrics.quic));
         out << "}\n";
 
-        QueueSample({ MetricType::kPublish, connection_handle, out.str() });
+        QueueSample({ out.str() });
     }
 
     void MetricsPublisher::QueueSubscribeMetrics(std::uint64_t connection_handle,
@@ -323,7 +328,7 @@ namespace laps {
         AppendUintField(out, first, "subscribers", static_cast<std::uint64_t>(subscriber_count));
         out << "}\n";
 
-        QueueSample({ MetricType::kSubscribe, connection_handle, out.str() });
+        QueueSample({ out.str() });
     }
 
     bool MetricsPublisher::QueueSample(MetricsSample sample)
@@ -363,21 +368,19 @@ namespace laps {
         std::optional<PublishTarget> target;
         {
             std::lock_guard<std::mutex> lock(tracks_mutex_);
-            auto track_it = tracks_.find(sample.type);
-            if (track_it != tracks_.end()) {
-                target = PublishTarget{ track_it->second.track_fullname_hash, track_it->second.next_group_id++ };
+            if (metrics_track_.has_value()) {
+                target = PublishTarget{ metrics_track_->track_fullname_hash, metrics_track_->next_group_id++ };
             }
         }
 
         if (!target.has_value()) {
             EnsureMetricsTracks();
             std::lock_guard<std::mutex> lock(tracks_mutex_);
-            auto track_it = tracks_.find(sample.type);
-            if (track_it == tracks_.end()) {
+            if (!metrics_track_.has_value()) {
                 return;
             }
 
-            target = PublishTarget{ track_it->second.track_fullname_hash, track_it->second.next_group_id++ };
+            target = PublishTarget{ metrics_track_->track_fullname_hash, metrics_track_->next_group_id++ };
         }
 
         if (target->track_fullname_hash == 0) {
@@ -411,54 +414,45 @@ namespace laps {
     {
         {
             std::lock_guard<std::mutex> lock(tracks_mutex_);
-            if (!tracks_.empty()) {
+            if (metrics_track_.has_value()) {
                 return;
             }
         }
 
-        std::map<MetricType, TrackState> tracks;
-        const MetricType metric_types[] = { MetricType::kConnection, MetricType::kSubscribe, MetricType::kPublish };
-        for (const auto type : metric_types) {
-            auto full_track_name = FullTrackNameFor(type);
-            const auto th = quicr::TrackHash(full_track_name);
+        auto full_track_name = MetricsTrackName();
+        const auto th = quicr::TrackHash(full_track_name);
 
-            SPDLOG_LOGGER_DEBUG(config_.logger_,
-                                "Creating relay-local metrics publish track namespace: {} name: {} alias: {}",
-                                full_track_name.NamespaceStr(),
-                                full_track_name.NameStr(),
-                                th.track_fullname_hash);
+        SPDLOG_LOGGER_DEBUG(config_.logger_,
+                            "Creating relay-local metrics publish track namespace: {} name: {} alias: {}",
+                            full_track_name.NamespaceStr(),
+                            full_track_name.NameStr(),
+                            th.track_fullname_hash);
 
-            const quicr::PublishAttributes attrs{ full_track_name,
-                                                  th.track_fullname_hash,
-                                                  {},
-                                                  std::nullopt,
-                                                  std::nullopt,
-                                                  true,
-                                                  quicr::messages::GroupOrder::kAscending,
-                                                  false,
-                                                  kDefaultPriority,
-                                                  std::nullopt,
-                                                  kDefaultObjectTtl,
-                                                  {} };
-            server_.PublishReceived(0, 0, attrs, {});
-            tracks.emplace(type, TrackState{ std::move(full_track_name), th.track_fullname_hash, 0 });
-        }
-
-        if (tracks.empty()) {
-            return;
-        }
+        const quicr::PublishAttributes attrs{ full_track_name,
+                                              th.track_fullname_hash,
+                                              {},
+                                              std::nullopt,
+                                              std::nullopt,
+                                              true,
+                                              quicr::messages::GroupOrder::kAscending,
+                                              false,
+                                              kDefaultPriority,
+                                              std::nullopt,
+                                              kDefaultObjectTtl,
+                                              {} };
+        server_.PublishReceived(0, 0, attrs, {});
 
         std::lock_guard<std::mutex> lock(tracks_mutex_);
-        tracks_ = std::move(tracks);
+        if (!metrics_track_.has_value()) {
+            metrics_track_ = TrackState{ std::move(full_track_name), th.track_fullname_hash, 0 };
+        }
     }
 
-    quicr::FullTrackName MetricsPublisher::FullTrackNameFor(MetricType type) const
+    quicr::FullTrackName MetricsPublisher::MetricsTrackName() const
     {
-        const std::string_view name = TypeName(type);
-
         quicr::FullTrackName full_track_name;
         full_track_name.name_space = quicr::TrackNamespace(metrics_namespace_entries_);
-        full_track_name.name = BytesFromString(name);
+        full_track_name.name = BytesFromString(kMetricsSchemaTrackName);
         return full_track_name;
     }
 

--- a/src/metrics_publisher.cc
+++ b/src/metrics_publisher.cc
@@ -357,7 +357,7 @@ namespace laps {
         struct PublishTarget
         {
             std::uint64_t track_fullname_hash{ 0 };
-            std::uint64_t object_id{ 0 };
+            std::uint64_t group_id{ 0 };
         };
 
         std::optional<PublishTarget> target;
@@ -365,7 +365,7 @@ namespace laps {
             std::lock_guard<std::mutex> lock(tracks_mutex_);
             auto track_it = tracks_.find(sample.type);
             if (track_it != tracks_.end()) {
-                target = PublishTarget{ track_it->second.track_fullname_hash, track_it->second.next_object_id++ };
+                target = PublishTarget{ track_it->second.track_fullname_hash, track_it->second.next_group_id++ };
             }
         }
 
@@ -377,7 +377,7 @@ namespace laps {
                 return;
             }
 
-            target = PublishTarget{ track_it->second.track_fullname_hash, track_it->second.next_object_id++ };
+            target = PublishTarget{ track_it->second.track_fullname_hash, track_it->second.next_group_id++ };
         }
 
         if (target->track_fullname_hash == 0) {
@@ -387,8 +387,9 @@ namespace laps {
         std::vector<std::uint8_t> payload(sample.json_line.begin(), sample.json_line.end());
 
         quicr::ObjectHeaders headers{};
-        headers.group_id = 0;
-        headers.object_id = target->object_id;
+        headers.group_id = target->group_id;
+        headers.object_id = 0;
+        headers.subgroup_id = 0;
         headers.payload_length = payload.size();
         headers.status = quicr::ObjectStatus::kAvailable;
         headers.priority = kDefaultPriority;

--- a/src/metrics_publisher.cc
+++ b/src/metrics_publisher.cc
@@ -3,8 +3,12 @@
 
 #include "metrics_publisher.h"
 
+#include "client_manager.h"
+
+#include <quicr/attributes.h>
 #include <quicr/messages/object.h>
 
+#include <optional>
 #include <sstream>
 #include <string_view>
 #include <vector>
@@ -35,11 +39,6 @@ namespace laps {
             }
 
             return entries;
-        }
-
-        quicr::TrackNamespace MakeTrackNamespace(const std::string& value, const std::string& relay_id)
-        {
-            return quicr::TrackNamespace(SplitNamespace(value, relay_id));
         }
 
         std::vector<std::uint8_t> BytesFromString(std::string_view value)
@@ -192,10 +191,10 @@ namespace laps {
         }
     } // namespace
 
-    MetricsPublisher::MetricsPublisher(quicr::Session& session, const Config& config)
-      : session_(session)
+    MetricsPublisher::MetricsPublisher(ClientManager& server, const Config& config)
+      : server_(server)
       , config_(config)
-      , metrics_namespace_(MakeTrackNamespace(config.metrics_namespace_, config.relay_id_))
+      , metrics_namespace_entries_(SplitNamespace(config.metrics_namespace_, config.relay_id_))
     {
     }
 
@@ -211,8 +210,9 @@ namespace laps {
             return;
         }
 
+        EnsureMetricsTracks();
         worker_ = std::thread(&MetricsPublisher::Run, this);
-        SPDLOG_LOGGER_INFO(config_.logger_, "Metrics publishing enabled on namespace {}", metrics_namespace_.Str());
+        SPDLOG_LOGGER_INFO(config_.logger_, "Metrics publishing enabled on namespace {}", MetricsNamespaceStr());
     }
 
     void MetricsPublisher::Stop()
@@ -239,7 +239,6 @@ namespace laps {
     void MetricsPublisher::RemoveConnection(std::uint64_t connection_handle)
     {
         std::lock_guard<std::mutex> lock(tracks_mutex_);
-        tracks_by_connection_.erase(connection_handle);
         remote_by_connection_.erase(connection_handle);
     }
 
@@ -355,62 +354,63 @@ namespace laps {
 
     void MetricsPublisher::PublishSample(const MetricsSample& sample)
     {
-        if (sample.connection_handle != 0) {
-            EnsureMetricsTracks(sample.connection_handle);
-        }
-
         struct PublishTarget
         {
-            std::shared_ptr<quicr::PublishTrackHandler> handler;
+            std::uint64_t track_fullname_hash{ 0 };
             std::uint64_t object_id{ 0 };
         };
 
-        std::vector<PublishTarget> targets;
+        std::optional<PublishTarget> target;
         {
             std::lock_guard<std::mutex> lock(tracks_mutex_);
-            for (auto& [_, tracks] : tracks_by_connection_) {
-                auto track_it = tracks.find(sample.type);
-                if (track_it == tracks.end() || !track_it->second.handler) {
-                    continue;
-                }
-
-                targets.push_back({ track_it->second.handler, track_it->second.next_object_id++ });
+            auto track_it = tracks_.find(sample.type);
+            if (track_it != tracks_.end()) {
+                target = PublishTarget{ track_it->second.track_fullname_hash, track_it->second.next_object_id++ };
             }
         }
 
-        if (targets.empty()) {
+        if (!target.has_value()) {
+            EnsureMetricsTracks();
+            std::lock_guard<std::mutex> lock(tracks_mutex_);
+            auto track_it = tracks_.find(sample.type);
+            if (track_it == tracks_.end()) {
+                return;
+            }
+
+            target = PublishTarget{ track_it->second.track_fullname_hash, track_it->second.next_object_id++ };
+        }
+
+        if (target->track_fullname_hash == 0) {
             return;
         }
 
         std::vector<std::uint8_t> payload(sample.json_line.begin(), sample.json_line.end());
-        for (const auto& target : targets) {
-            quicr::ObjectHeaders headers{};
-            headers.group_id = 0;
-            headers.object_id = target.object_id;
-            headers.payload_length = payload.size();
-            headers.status = quicr::ObjectStatus::kAvailable;
-            headers.priority = kDefaultPriority;
-            headers.ttl = static_cast<std::uint16_t>(kDefaultObjectTtl);
 
-            try {
-                const auto status = target.handler->PublishObject(headers, payload);
-                if (status != quicr::PublishTrackHandler::PublishObjectStatus::kOk &&
-                    status != quicr::PublishTrackHandler::PublishObjectStatus::kNoSubscribers &&
-                    status != quicr::PublishTrackHandler::PublishObjectStatus::kPendingPublishOk) {
-                    SPDLOG_LOGGER_DEBUG(
-                      config_.logger_, "Metrics publish returned status {}", static_cast<std::uint8_t>(status));
-                }
-            } catch (const std::exception& e) {
-                SPDLOG_LOGGER_DEBUG(config_.logger_, "Metrics publish failed: {}", e.what());
+        quicr::ObjectHeaders headers{};
+        headers.group_id = 0;
+        headers.object_id = target->object_id;
+        headers.payload_length = payload.size();
+        headers.status = quicr::ObjectStatus::kAvailable;
+        headers.priority = kDefaultPriority;
+        headers.ttl = static_cast<std::uint16_t>(kDefaultObjectTtl);
+        headers.track_mode = quicr::TrackMode::kDatagram;
+
+        try {
+            if (!server_.PublishLocalObject(target->track_fullname_hash, headers, payload)) {
+                SPDLOG_LOGGER_DEBUG(config_.logger_,
+                                    "Metrics local publish track missing for track alias {}",
+                                    target->track_fullname_hash);
             }
+        } catch (const std::exception& e) {
+            SPDLOG_LOGGER_DEBUG(config_.logger_, "Metrics publish failed: {}", e.what());
         }
     }
 
-    void MetricsPublisher::EnsureMetricsTracks(std::uint64_t connection_handle)
+    void MetricsPublisher::EnsureMetricsTracks()
     {
         {
             std::lock_guard<std::mutex> lock(tracks_mutex_);
-            if (tracks_by_connection_.contains(connection_handle)) {
+            if (!tracks_.empty()) {
                 return;
             }
         }
@@ -418,11 +418,29 @@ namespace laps {
         std::map<MetricType, TrackState> tracks;
         const MetricType metric_types[] = { MetricType::kConnection, MetricType::kSubscribe, MetricType::kPublish };
         for (const auto type : metric_types) {
-            auto handler = CreateTrackHandler(type);
-            session_.PublishTrack(connection_handle, handler);
-            if (handler->GetRequestId().has_value()) {
-                tracks.emplace(type, TrackState{ std::move(handler), 0 });
-            }
+            auto full_track_name = FullTrackNameFor(type);
+            const auto th = quicr::TrackHash(full_track_name);
+
+            SPDLOG_LOGGER_DEBUG(config_.logger_,
+                                "Creating relay-local metrics publish track namespace: {} name: {} alias: {}",
+                                full_track_name.NamespaceStr(),
+                                full_track_name.NameStr(),
+                                th.track_fullname_hash);
+
+            const quicr::PublishAttributes attrs{ full_track_name,
+                                                  th.track_fullname_hash,
+                                                  {},
+                                                  std::nullopt,
+                                                  std::nullopt,
+                                                  true,
+                                                  quicr::messages::GroupOrder::kAscending,
+                                                  false,
+                                                  kDefaultPriority,
+                                                  std::nullopt,
+                                                  kDefaultObjectTtl,
+                                                  {} };
+            server_.PublishReceived(0, 0, attrs, {});
+            tracks.emplace(type, TrackState{ std::move(full_track_name), th.track_fullname_hash, 0 });
         }
 
         if (tracks.empty()) {
@@ -430,19 +448,22 @@ namespace laps {
         }
 
         std::lock_guard<std::mutex> lock(tracks_mutex_);
-        tracks_by_connection_.try_emplace(connection_handle, std::move(tracks));
-    }
-
-    std::shared_ptr<quicr::PublishTrackHandler> MetricsPublisher::CreateTrackHandler(MetricType type) const
-    {
-        return quicr::PublishTrackHandler::Create(
-          FullTrackNameFor(type), quicr::TrackMode::kDatagram, kDefaultPriority, kDefaultObjectTtl, { 0, 0 });
+        tracks_ = std::move(tracks);
     }
 
     quicr::FullTrackName MetricsPublisher::FullTrackNameFor(MetricType type) const
     {
         const std::string_view name = TypeName(type);
-        return { metrics_namespace_, BytesFromString(name) };
+
+        quicr::FullTrackName full_track_name;
+        full_track_name.name_space = quicr::TrackNamespace(metrics_namespace_entries_);
+        full_track_name.name = BytesFromString(name);
+        return full_track_name;
+    }
+
+    std::string MetricsPublisher::MetricsNamespaceStr() const
+    {
+        return quicr::TrackNamespace(metrics_namespace_entries_).Str();
     }
 
     const char* MetricsPublisher::TypeName(MetricType type)

--- a/src/metrics_publisher.cc
+++ b/src/metrics_publisher.cc
@@ -1,0 +1,461 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "metrics_publisher.h"
+
+#include <quicr/messages/object.h>
+
+#include <sstream>
+#include <string_view>
+#include <vector>
+
+namespace laps {
+    namespace {
+        std::vector<std::string> SplitNamespace(const std::string& value, const std::string& relay_id)
+        {
+            const std::string namespace_value = value.empty() ? "metrics/" + relay_id : value;
+            std::vector<std::string> entries;
+
+            std::size_t start = 0;
+            while (start <= namespace_value.size()) {
+                const auto slash = namespace_value.find('/', start);
+                const auto end = slash == std::string::npos ? namespace_value.size() : slash;
+                if (end > start) {
+                    entries.emplace_back(namespace_value.substr(start, end - start));
+                }
+                if (slash == std::string::npos) {
+                    break;
+                }
+                start = slash + 1;
+            }
+
+            if (entries.empty()) {
+                entries.emplace_back("metrics");
+                entries.emplace_back(relay_id);
+            }
+
+            return entries;
+        }
+
+        quicr::TrackNamespace MakeTrackNamespace(const std::string& value, const std::string& relay_id)
+        {
+            return quicr::TrackNamespace(SplitNamespace(value, relay_id));
+        }
+
+        std::vector<std::uint8_t> BytesFromString(std::string_view value)
+        {
+            return { value.begin(), value.end() };
+        }
+
+        std::string JsonEscape(std::string_view value)
+        {
+            std::string escaped;
+            escaped.reserve(value.size());
+
+            constexpr char kHex[] = "0123456789abcdef";
+            for (const auto ch : value) {
+                const auto c = static_cast<unsigned char>(ch);
+                switch (c) {
+                    case '"':
+                        escaped += "\\\"";
+                        break;
+                    case '\\':
+                        escaped += "\\\\";
+                        break;
+                    case '\b':
+                        escaped += "\\b";
+                        break;
+                    case '\f':
+                        escaped += "\\f";
+                        break;
+                    case '\n':
+                        escaped += "\\n";
+                        break;
+                    case '\r':
+                        escaped += "\\r";
+                        break;
+                    case '\t':
+                        escaped += "\\t";
+                        break;
+                    default:
+                        if (c < 0x20 || c > 0x7e) {
+                            escaped += "\\u00";
+                            escaped.push_back(kHex[(c >> 4) & 0x0f]);
+                            escaped.push_back(kHex[c & 0x0f]);
+                        } else {
+                            escaped.push_back(static_cast<char>(c));
+                        }
+                        break;
+                }
+            }
+
+            return escaped;
+        }
+
+        void AppendComma(std::ostringstream& out, bool& first)
+        {
+            if (!first) {
+                out << ',';
+            }
+            first = false;
+        }
+
+        void AppendStringField(std::ostringstream& out, bool& first, std::string_view key, std::string_view value)
+        {
+            AppendComma(out, first);
+            out << '"' << key << "\":\"" << JsonEscape(value) << '"';
+        }
+
+        void AppendUintField(std::ostringstream& out, bool& first, std::string_view key, std::uint64_t value)
+        {
+            AppendComma(out, first);
+            out << '"' << key << "\":" << value;
+        }
+
+        void AppendRawField(std::ostringstream& out, bool& first, std::string_view key, std::string_view value)
+        {
+            AppendComma(out, first);
+            out << '"' << key << "\":" << value;
+        }
+
+        std::string SerializeMinMaxAvg(const quicr::MinMaxAvg& metrics)
+        {
+            std::ostringstream out;
+            bool first = true;
+            out << '{';
+            AppendUintField(out, first, "min", metrics.min);
+            AppendUintField(out, first, "max", metrics.max);
+            AppendUintField(out, first, "avg", metrics.avg);
+            AppendUintField(out, first, "value_sum", metrics.value_sum);
+            AppendUintField(out, first, "value_count", metrics.value_count);
+            out << '}';
+            return out.str();
+        }
+
+        std::string SerializeConnectionQuic(const quicr::QuicConnectionMetrics& metrics)
+        {
+            std::ostringstream out;
+            bool first = true;
+            out << '{';
+            AppendUintField(out, first, "cwin_congested", metrics.cwin_congested);
+            AppendUintField(out, first, "prev_cwin_congested", metrics.prev_cwin_congested);
+            AppendUintField(out, first, "tx_congested", metrics.tx_congested);
+            AppendRawField(out, first, "tx_rate_bps", SerializeMinMaxAvg(metrics.tx_rate_bps));
+            AppendRawField(out, first, "rx_rate_bps", SerializeMinMaxAvg(metrics.rx_rate_bps));
+            AppendRawField(out, first, "tx_cwin_bytes", SerializeMinMaxAvg(metrics.tx_cwin_bytes));
+            AppendRawField(out, first, "tx_in_transit_bytes", SerializeMinMaxAvg(metrics.tx_in_transit_bytes));
+            AppendRawField(out, first, "rtt_us", SerializeMinMaxAvg(metrics.rtt_us));
+            AppendRawField(out, first, "srtt_us", SerializeMinMaxAvg(metrics.srtt_us));
+            AppendUintField(out, first, "tx_retransmits", metrics.tx_retransmits);
+            AppendUintField(out, first, "tx_lost_pkts", metrics.tx_lost_pkts);
+            AppendUintField(out, first, "tx_timer_losses", metrics.tx_timer_losses);
+            AppendUintField(out, first, "tx_spurious_losses", metrics.tx_spurious_losses);
+            AppendUintField(out, first, "rx_dgrams", metrics.rx_dgrams);
+            AppendUintField(out, first, "rx_dgrams_bytes", metrics.rx_dgrams_bytes);
+            AppendUintField(out, first, "tx_dgram_cb", metrics.tx_dgram_cb);
+            AppendUintField(out, first, "tx_dgram_ack", metrics.tx_dgram_ack);
+            AppendUintField(out, first, "tx_dgram_lost", metrics.tx_dgram_lost);
+            AppendUintField(out, first, "tx_dgram_spurious", metrics.tx_dgram_spurious);
+            AppendUintField(out, first, "tx_dgram_drops", metrics.tx_dgram_drops);
+            out << '}';
+            return out.str();
+        }
+
+        std::string SerializePublishQuic(const quicr::PublishTrackMetrics::Quic& metrics)
+        {
+            std::ostringstream out;
+            bool first = true;
+            out << '{';
+            AppendUintField(out, first, "tx_buffer_drops", metrics.tx_buffer_drops);
+            AppendUintField(out, first, "tx_queue_discards", metrics.tx_queue_discards);
+            AppendUintField(out, first, "tx_queue_expired", metrics.tx_queue_expired);
+            AppendUintField(out, first, "tx_delayed_callback", metrics.tx_delayed_callback);
+            AppendUintField(out, first, "tx_reset_wait", metrics.tx_reset_wait);
+            AppendRawField(out, first, "tx_queue_size", SerializeMinMaxAvg(metrics.tx_queue_size));
+            AppendRawField(out, first, "tx_callback_ms", SerializeMinMaxAvg(metrics.tx_callback_ms));
+            AppendRawField(out, first, "tx_object_duration_us", SerializeMinMaxAvg(metrics.tx_object_duration_us));
+            out << '}';
+            return out.str();
+        }
+
+        void AppendCommonFields(std::ostringstream& out,
+                                bool& first,
+                                std::string_view type,
+                                const std::string& relay_id,
+                                std::uint64_t sample_time_us,
+                                std::uint64_t connection_handle)
+        {
+            AppendStringField(out, first, "type", type);
+            AppendStringField(out, first, "relay_id", relay_id);
+            AppendUintField(out, first, "sample_time_us", sample_time_us);
+            AppendUintField(out, first, "connection_handle", connection_handle);
+        }
+    } // namespace
+
+    MetricsPublisher::MetricsPublisher(quicr::Session& session, const Config& config)
+      : session_(session)
+      , config_(config)
+      , metrics_namespace_(MakeTrackNamespace(config.metrics_namespace_, config.relay_id_))
+    {
+    }
+
+    MetricsPublisher::~MetricsPublisher()
+    {
+        Stop();
+    }
+
+    void MetricsPublisher::Start()
+    {
+        bool expected = false;
+        if (!running_.compare_exchange_strong(expected, true)) {
+            return;
+        }
+
+        worker_ = std::thread(&MetricsPublisher::Run, this);
+        SPDLOG_LOGGER_INFO(config_.logger_, "Metrics publishing enabled on namespace {}", metrics_namespace_.Str());
+    }
+
+    void MetricsPublisher::Stop()
+    {
+        const bool was_running = running_.exchange(false);
+        queue_.StopWaiting();
+
+        if (worker_.joinable()) {
+            worker_.join();
+        }
+
+        if (was_running) {
+            SPDLOG_LOGGER_INFO(config_.logger_, "Metrics publishing stopped");
+        }
+    }
+
+    void MetricsPublisher::AddConnection(std::uint64_t connection_handle,
+                                         const quicr::Session::ConnectionRemoteInfo& remote)
+    {
+        std::lock_guard<std::mutex> lock(tracks_mutex_);
+        remote_by_connection_[connection_handle] = { remote.ip, remote.port };
+    }
+
+    void MetricsPublisher::RemoveConnection(std::uint64_t connection_handle)
+    {
+        std::lock_guard<std::mutex> lock(tracks_mutex_);
+        tracks_by_connection_.erase(connection_handle);
+        remote_by_connection_.erase(connection_handle);
+    }
+
+    void MetricsPublisher::QueueConnectionMetrics(std::uint64_t connection_handle,
+                                                  std::size_t publish_track_count,
+                                                  const quicr::ConnectionMetrics& metrics)
+    {
+        RemoteInfo remote_info;
+        {
+            std::lock_guard<std::mutex> lock(tracks_mutex_);
+            if (const auto remote_it = remote_by_connection_.find(connection_handle);
+                remote_it != remote_by_connection_.end()) {
+                remote_info = remote_it->second;
+            }
+        }
+
+        std::ostringstream out;
+        bool first = true;
+        out << '{';
+        AppendCommonFields(out,
+                           first,
+                           TypeName(MetricType::kConnection),
+                           config_.relay_id_,
+                           metrics.last_sample_time,
+                           connection_handle);
+        AppendStringField(out, first, "remote_ip", remote_info.ip);
+        AppendUintField(out, first, "remote_port", remote_info.port);
+        AppendUintField(out, first, "publish_tracks", static_cast<std::uint64_t>(publish_track_count));
+        AppendUintField(out, first, "rx_dgram_unknown_track_alias", metrics.rx_dgram_unknown_track_alias);
+        AppendUintField(out, first, "rx_dgram_invalid_type", metrics.rx_dgram_invalid_type);
+        AppendUintField(out, first, "rx_dgram_decode_failed", metrics.rx_dgram_decode_failed);
+        AppendUintField(out, first, "rx_stream_buffer_error", metrics.rx_stream_buffer_error);
+        AppendUintField(out, first, "rx_stream_unknown_track_alias", metrics.rx_stream_unknown_track_alias);
+        AppendUintField(out, first, "rx_stream_invalid_type", metrics.rx_stream_invalid_type);
+        AppendUintField(out, first, "invalid_ctrl_stream_msg", metrics.invalid_ctrl_stream_msg);
+        AppendRawField(out, first, "quic", SerializeConnectionQuic(metrics.quic));
+        out << "}\n";
+
+        QueueSample({ MetricType::kConnection, connection_handle, out.str() });
+    }
+
+    void MetricsPublisher::QueuePublishMetrics(std::uint64_t connection_handle,
+                                               const quicr::FullTrackName& track_name,
+                                               const quicr::PublishTrackMetrics& metrics)
+    {
+        const auto track_namespace = track_name.NamespaceStr();
+        const auto name = track_name.NameStr();
+
+        std::ostringstream out;
+        bool first = true;
+        out << '{';
+        AppendCommonFields(
+          out, first, TypeName(MetricType::kPublish), config_.relay_id_, metrics.last_sample_time, connection_handle);
+        AppendStringField(out, first, "track_namespace", track_namespace);
+        AppendStringField(out, first, "track_name", name);
+        AppendUintField(out, first, "bytes_published", metrics.bytes_published);
+        AppendUintField(out, first, "objects_published", metrics.objects_published);
+        AppendUintField(out, first, "objects_dropped_not_ok", metrics.objects_dropped_not_ok);
+        AppendRawField(out, first, "quic", SerializePublishQuic(metrics.quic));
+        out << "}\n";
+
+        QueueSample({ MetricType::kPublish, connection_handle, out.str() });
+    }
+
+    void MetricsPublisher::QueueSubscribeMetrics(std::uint64_t connection_handle,
+                                                 const quicr::FullTrackName& track_name,
+                                                 std::size_t subscriber_count,
+                                                 const quicr::SubscribeTrackMetrics& metrics)
+    {
+        const auto track_namespace = track_name.NamespaceStr();
+        const auto name = track_name.NameStr();
+
+        std::ostringstream out;
+        bool first = true;
+        out << '{';
+        AppendCommonFields(
+          out, first, TypeName(MetricType::kSubscribe), config_.relay_id_, metrics.last_sample_time, connection_handle);
+        AppendStringField(out, first, "track_namespace", track_namespace);
+        AppendStringField(out, first, "track_name", name);
+        AppendUintField(out, first, "bytes_received", metrics.bytes_received);
+        AppendUintField(out, first, "objects_received", metrics.objects_received);
+        AppendUintField(out, first, "subscribers", static_cast<std::uint64_t>(subscriber_count));
+        out << "}\n";
+
+        QueueSample({ MetricType::kSubscribe, connection_handle, out.str() });
+    }
+
+    bool MetricsPublisher::QueueSample(MetricsSample sample)
+    {
+        if (!running_) {
+            return false;
+        }
+
+        const auto pushed = queue_.Push(std::move(sample));
+        if (!pushed) {
+            SPDLOG_LOGGER_DEBUG(config_.logger_, "Metrics queue full, dropped oldest sample");
+        }
+
+        return pushed;
+    }
+
+    void MetricsPublisher::Run()
+    {
+        while (running_) {
+            auto sample = queue_.BlockPop();
+            if (!sample.has_value()) {
+                break;
+            }
+
+            PublishSample(*sample);
+        }
+    }
+
+    void MetricsPublisher::PublishSample(const MetricsSample& sample)
+    {
+        if (sample.connection_handle != 0) {
+            EnsureMetricsTracks(sample.connection_handle);
+        }
+
+        struct PublishTarget
+        {
+            std::shared_ptr<quicr::PublishTrackHandler> handler;
+            std::uint64_t object_id{ 0 };
+        };
+
+        std::vector<PublishTarget> targets;
+        {
+            std::lock_guard<std::mutex> lock(tracks_mutex_);
+            for (auto& [_, tracks] : tracks_by_connection_) {
+                auto track_it = tracks.find(sample.type);
+                if (track_it == tracks.end() || !track_it->second.handler) {
+                    continue;
+                }
+
+                targets.push_back({ track_it->second.handler, track_it->second.next_object_id++ });
+            }
+        }
+
+        if (targets.empty()) {
+            return;
+        }
+
+        std::vector<std::uint8_t> payload(sample.json_line.begin(), sample.json_line.end());
+        for (const auto& target : targets) {
+            quicr::ObjectHeaders headers{};
+            headers.group_id = 0;
+            headers.object_id = target.object_id;
+            headers.payload_length = payload.size();
+            headers.status = quicr::ObjectStatus::kAvailable;
+            headers.priority = kDefaultPriority;
+            headers.ttl = static_cast<std::uint16_t>(kDefaultObjectTtl);
+
+            try {
+                const auto status = target.handler->PublishObject(headers, payload);
+                if (status != quicr::PublishTrackHandler::PublishObjectStatus::kOk &&
+                    status != quicr::PublishTrackHandler::PublishObjectStatus::kNoSubscribers &&
+                    status != quicr::PublishTrackHandler::PublishObjectStatus::kPendingPublishOk) {
+                    SPDLOG_LOGGER_DEBUG(
+                      config_.logger_, "Metrics publish returned status {}", static_cast<std::uint8_t>(status));
+                }
+            } catch (const std::exception& e) {
+                SPDLOG_LOGGER_DEBUG(config_.logger_, "Metrics publish failed: {}", e.what());
+            }
+        }
+    }
+
+    void MetricsPublisher::EnsureMetricsTracks(std::uint64_t connection_handle)
+    {
+        {
+            std::lock_guard<std::mutex> lock(tracks_mutex_);
+            if (tracks_by_connection_.contains(connection_handle)) {
+                return;
+            }
+        }
+
+        std::map<MetricType, TrackState> tracks;
+        const MetricType metric_types[] = { MetricType::kConnection, MetricType::kSubscribe, MetricType::kPublish };
+        for (const auto type : metric_types) {
+            auto handler = CreateTrackHandler(type);
+            session_.PublishTrack(connection_handle, handler);
+            if (handler->GetRequestId().has_value()) {
+                tracks.emplace(type, TrackState{ std::move(handler), 0 });
+            }
+        }
+
+        if (tracks.empty()) {
+            return;
+        }
+
+        std::lock_guard<std::mutex> lock(tracks_mutex_);
+        tracks_by_connection_.try_emplace(connection_handle, std::move(tracks));
+    }
+
+    std::shared_ptr<quicr::PublishTrackHandler> MetricsPublisher::CreateTrackHandler(MetricType type) const
+    {
+        return quicr::PublishTrackHandler::Create(
+          FullTrackNameFor(type), quicr::TrackMode::kDatagram, kDefaultPriority, kDefaultObjectTtl, { 0, 0 });
+    }
+
+    quicr::FullTrackName MetricsPublisher::FullTrackNameFor(MetricType type) const
+    {
+        const std::string_view name = TypeName(type);
+        return { metrics_namespace_, BytesFromString(name) };
+    }
+
+    const char* MetricsPublisher::TypeName(MetricType type)
+    {
+        switch (type) {
+            case MetricType::kConnection:
+                return "connection";
+            case MetricType::kSubscribe:
+                return "subscribe";
+            case MetricType::kPublish:
+                return "publish";
+        }
+
+        return "unknown";
+    }
+} // namespace laps

--- a/src/metrics_publisher.cc
+++ b/src/metrics_publisher.cc
@@ -248,7 +248,15 @@ namespace laps {
                                          const quicr::Session::ConnectionRemoteInfo& remote)
     {
         std::lock_guard<std::mutex> lock(tracks_mutex_);
-        remote_by_connection_[connection_handle] = { remote.ip, remote.port };
+        auto& remote_info = remote_by_connection_[connection_handle];
+        remote_info.ip = remote.ip;
+        remote_info.port = remote.port;
+    }
+
+    void MetricsPublisher::SetConnectionEndpointId(std::uint64_t connection_handle, const std::string& endpoint_id)
+    {
+        std::lock_guard<std::mutex> lock(tracks_mutex_);
+        remote_by_connection_[connection_handle].endpoint_id = endpoint_id;
     }
 
     void MetricsPublisher::RemoveConnection(std::uint64_t connection_handle)
@@ -257,18 +265,21 @@ namespace laps {
         remote_by_connection_.erase(connection_handle);
     }
 
+    MetricsPublisher::RemoteInfo MetricsPublisher::LookupRemote(std::uint64_t connection_handle)
+    {
+        std::lock_guard<std::mutex> lock(tracks_mutex_);
+        if (const auto it = remote_by_connection_.find(connection_handle); it != remote_by_connection_.end()) {
+            return it->second;
+        }
+
+        return {};
+    }
+
     void MetricsPublisher::QueueConnectionMetrics(std::uint64_t connection_handle,
                                                   std::size_t publish_track_count,
                                                   const quicr::ConnectionMetrics& metrics)
     {
-        RemoteInfo remote_info;
-        {
-            std::lock_guard<std::mutex> lock(tracks_mutex_);
-            if (const auto remote_it = remote_by_connection_.find(connection_handle);
-                remote_it != remote_by_connection_.end()) {
-                remote_info = remote_it->second;
-            }
-        }
+        const auto remote_info = LookupRemote(connection_handle);
 
         std::ostringstream out;
         bool first = true;
@@ -279,6 +290,7 @@ namespace laps {
                            config_.relay_id_,
                            metrics.last_sample_time,
                            connection_handle);
+        AppendStringField(out, first, "remote_endpoint_id", remote_info.endpoint_id);
         AppendStringField(out, first, "remote_ip", remote_info.ip);
         AppendUintField(out, first, "remote_port", remote_info.port);
         AppendUintField(out, first, "publish_tracks", static_cast<std::uint64_t>(publish_track_count));
@@ -301,12 +313,14 @@ namespace laps {
     {
         const auto track_namespace = track_name.NamespaceStr();
         const auto name = track_name.NameStr();
+        const auto remote_info = LookupRemote(connection_handle);
 
         std::ostringstream out;
         bool first = true;
         out << '{';
         AppendCommonFields(
           out, first, TypeName(MetricType::kPublish), config_.relay_id_, metrics.last_sample_time, connection_handle);
+        AppendStringField(out, first, "remote_endpoint_id", remote_info.endpoint_id);
         AppendStringField(out, first, "track_namespace", track_namespace);
         AppendStringField(out, first, "track_name", name);
         AppendUintField(out, first, "bytes_published", metrics.bytes_published);

--- a/src/metrics_publisher.cc
+++ b/src/metrics_publisher.cc
@@ -277,6 +277,7 @@ namespace laps {
 
     void MetricsPublisher::QueueConnectionMetrics(std::uint64_t connection_handle,
                                                   std::size_t publish_track_count,
+                                                  std::size_t subscribe_track_count,
                                                   const quicr::ConnectionMetrics& metrics)
     {
         const auto remote_info = LookupRemote(connection_handle);
@@ -293,7 +294,8 @@ namespace laps {
         AppendStringField(out, first, "remote_endpoint_id", remote_info.endpoint_id);
         AppendStringField(out, first, "remote_ip", remote_info.ip);
         AppendUintField(out, first, "remote_port", remote_info.port);
-        AppendUintField(out, first, "publish_tracks", static_cast<std::uint64_t>(publish_track_count));
+        AppendUintField(out, first, "publish_tracks", publish_track_count);
+        AppendUintField(out, first, "subscribe_tracks", subscribe_track_count);
         AppendUintField(out, first, "rx_dgram_unknown_track_alias", metrics.rx_dgram_unknown_track_alias);
         AppendUintField(out, first, "rx_dgram_invalid_type", metrics.rx_dgram_invalid_type);
         AppendUintField(out, first, "rx_dgram_decode_failed", metrics.rx_dgram_decode_failed);

--- a/src/metrics_publisher.h
+++ b/src/metrics_publisher.h
@@ -64,10 +64,10 @@ namespace laps {
                                     const quicr::ConnectionMetrics& metrics);
         void QueuePublishMetrics(std::uint64_t connection_handle,
                                  const quicr::FullTrackName& track_name,
+                                 std::size_t subscriber_count,
                                  const quicr::PublishTrackMetrics& metrics);
         void QueueSubscribeMetrics(std::uint64_t connection_handle,
                                    const quicr::FullTrackName& track_name,
-                                   std::size_t subscriber_count,
                                    const quicr::SubscribeTrackMetrics& metrics);
 
       private:

--- a/src/metrics_publisher.h
+++ b/src/metrics_publisher.h
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+#pragma once
+
+#include "config.h"
+
+#include <quicr/handlers/publish_track_handler.h>
+#include <quicr/containers/safe_queue.h>
+#include <quicr/metrics.h>
+#include <quicr/session.h>
+#include <quicr/track_name.h>
+
+#include <atomic>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace laps {
+    /**
+     * @brief Publishes relay metrics samples as JSON lines over MoQ tracks.
+     */
+    class MetricsPublisher
+    {
+      public:
+        MetricsPublisher(quicr::Session& session, const Config& config);
+        ~MetricsPublisher();
+
+        MetricsPublisher(const MetricsPublisher&) = delete;
+        MetricsPublisher& operator=(const MetricsPublisher&) = delete;
+
+        void Start();
+        void Stop();
+
+        void AddConnection(std::uint64_t connection_handle, const quicr::Session::ConnectionRemoteInfo& remote);
+        void RemoveConnection(std::uint64_t connection_handle);
+
+        void QueueConnectionMetrics(std::uint64_t connection_handle,
+                                    std::size_t publish_track_count,
+                                    const quicr::ConnectionMetrics& metrics);
+        void QueuePublishMetrics(std::uint64_t connection_handle,
+                                 const quicr::FullTrackName& track_name,
+                                 const quicr::PublishTrackMetrics& metrics);
+        void QueueSubscribeMetrics(std::uint64_t connection_handle,
+                                   const quicr::FullTrackName& track_name,
+                                   std::size_t subscriber_count,
+                                   const quicr::SubscribeTrackMetrics& metrics);
+
+      private:
+        enum class MetricType : std::uint8_t
+        {
+            kConnection,
+            kSubscribe,
+            kPublish,
+        };
+
+        struct MetricsSample
+        {
+            MetricType type;
+            std::uint64_t connection_handle{ 0 };
+            std::string json_line;
+        };
+
+        struct TrackState
+        {
+            std::shared_ptr<quicr::PublishTrackHandler> handler;
+            std::uint64_t next_object_id{ 0 };
+        };
+
+        struct RemoteInfo
+        {
+            std::string ip;
+            std::uint16_t port{ 0 };
+        };
+
+        static constexpr std::uint32_t kQueueLimit = 5'000;
+
+        void Run();
+        void PublishSample(const MetricsSample& sample);
+        void EnsureMetricsTracks(std::uint64_t connection_handle);
+        std::shared_ptr<quicr::PublishTrackHandler> CreateTrackHandler(MetricType type) const;
+        quicr::FullTrackName FullTrackNameFor(MetricType type) const;
+        static const char* TypeName(MetricType type);
+
+        bool QueueSample(MetricsSample sample);
+
+        quicr::Session& session_;
+        const Config& config_;
+        quicr::TrackNamespace metrics_namespace_;
+
+        quicr::SafeQueue<MetricsSample> queue_{ kQueueLimit };
+        std::atomic_bool running_{ false };
+        std::thread worker_;
+
+        std::mutex tracks_mutex_;
+        std::map<std::uint64_t, std::map<MetricType, TrackState>> tracks_by_connection_;
+        std::map<std::uint64_t, RemoteInfo> remote_by_connection_;
+    };
+} // namespace laps

--- a/src/metrics_publisher.h
+++ b/src/metrics_publisher.h
@@ -70,7 +70,7 @@ namespace laps {
         {
             quicr::FullTrackName full_track_name;
             std::uint64_t track_fullname_hash{ 0 };
-            std::uint64_t next_object_id{ 0 };
+            std::uint64_t next_group_id{ 0 };
         };
 
         struct RemoteInfo

--- a/src/metrics_publisher.h
+++ b/src/metrics_publisher.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -61,8 +62,6 @@ namespace laps {
 
         struct MetricsSample
         {
-            MetricType type;
-            std::uint64_t connection_handle{ 0 };
             std::string json_line;
         };
 
@@ -84,7 +83,7 @@ namespace laps {
         void Run();
         void PublishSample(const MetricsSample& sample);
         void EnsureMetricsTracks();
-        quicr::FullTrackName FullTrackNameFor(MetricType type) const;
+        quicr::FullTrackName MetricsTrackName() const;
         std::string MetricsNamespaceStr() const;
         static const char* TypeName(MetricType type);
 
@@ -99,7 +98,7 @@ namespace laps {
         std::thread worker_;
 
         std::mutex tracks_mutex_;
-        std::map<MetricType, TrackState> tracks_;
+        std::optional<TrackState> metrics_track_;
         std::map<std::uint64_t, RemoteInfo> remote_by_connection_;
     };
 } // namespace laps

--- a/src/metrics_publisher.h
+++ b/src/metrics_publisher.h
@@ -56,6 +56,7 @@ namespace laps {
         void Stop();
 
         void AddConnection(std::uint64_t connection_handle, const quicr::Session::ConnectionRemoteInfo& remote);
+        void SetConnectionEndpointId(std::uint64_t connection_handle, const std::string& endpoint_id);
         void RemoveConnection(std::uint64_t connection_handle);
 
         void QueueConnectionMetrics(std::uint64_t connection_handle,
@@ -93,6 +94,9 @@ namespace laps {
         {
             std::string ip;
             std::uint16_t port{ 0 };
+
+            /// Remote MoQ endpoint ID from CLIENT_SETUP. Empty until setup is received.
+            std::string endpoint_id;
         };
 
         static constexpr std::uint32_t kQueueLimit = 5'000;
@@ -105,6 +109,8 @@ namespace laps {
         quicr::FullTrackName MetricsTrackName() const;
         std::string MetricsNamespaceStr() const;
         static const char* TypeName(MetricType type);
+
+        RemoteInfo LookupRemote(std::uint64_t connection_handle);
 
         bool QueueSample(MetricsSample sample);
 

--- a/src/metrics_publisher.h
+++ b/src/metrics_publisher.h
@@ -11,6 +11,8 @@
 #include <quicr/track_name.h>
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -25,6 +27,21 @@ namespace laps {
 
     /**
      * @brief Publishes relay metrics samples as JSON lines over MoQ tracks.
+     *
+     * @details Metrics samples arrive via Queue*Metrics(), always called from MetricsSampled() callbacks on
+     *      the relay's transport thread. That call must stay cheap (just an enqueue) so it never delays the
+     *      transport thread. A dedicated worker thread periodically (every kBatchIntervalMs) drains the
+     *      queue and coalesces the pending JSON lines into a single batch -- pure CPU work that never
+     *      touches ClientManager or libquicr handler state, so it's safe to run off the transport thread.
+     *
+     *      Actually publishing a batch (EnsureMetricsTracks()/PublishLocalObject(), which read/write
+     *      ClientManager's state_ maps and libquicr handler objects such as PublishTrackHandler's internal
+     *      stream state) must still happen only on the transport thread: those structures are unsynchronized
+     *      and are mutated directly by libquicr (e.g. Session::BindPublisherTrack()) with no locking. So the
+     *      worker thread only stages a finished batch; the next Queue*Metrics() call (on the transport
+     *      thread) picks it up and publishes it. This keeps the expensive/blocking work (batching) off the
+     *      transport thread while keeping every unsafe-to-share call on the one thread that's allowed to
+     *      make it.
      */
     class MetricsPublisher
     {
@@ -79,8 +96,10 @@ namespace laps {
         };
 
         static constexpr std::uint32_t kQueueLimit = 5'000;
+        static constexpr std::chrono::milliseconds kBatchInterval{ 150 };
 
-        void Run();
+        void WorkerRun();
+        void FlushPendingBatch();
         void PublishSample(const MetricsSample& sample);
         void EnsureMetricsTracks();
         quicr::FullTrackName MetricsTrackName() const;
@@ -95,7 +114,16 @@ namespace laps {
 
         quicr::SafeQueue<MetricsSample> queue_{ kQueueLimit };
         std::atomic_bool running_{ false };
+
+        /// Batches JSON lines pulled off queue_ on its own schedule; never touches ClientManager/libquicr.
         std::thread worker_;
+        std::mutex worker_mutex_;
+        std::condition_variable worker_cv_;
+
+        /// Hand-off slot: worker_ stages a finished batch here; the transport thread (via QueueSample()) is
+        /// the only thread that consumes it, since publishing must happen there.
+        std::mutex pending_batch_mutex_;
+        std::optional<MetricsSample> pending_batch_;
 
         std::mutex tracks_mutex_;
         std::optional<TrackState> metrics_track_;

--- a/src/metrics_publisher.h
+++ b/src/metrics_publisher.h
@@ -5,7 +5,6 @@
 
 #include "config.h"
 
-#include <quicr/handlers/publish_track_handler.h>
 #include <quicr/containers/safe_queue.h>
 #include <quicr/metrics.h>
 #include <quicr/session.h>
@@ -18,15 +17,18 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <vector>
 
 namespace laps {
+    class ClientManager;
+
     /**
      * @brief Publishes relay metrics samples as JSON lines over MoQ tracks.
      */
     class MetricsPublisher
     {
       public:
-        MetricsPublisher(quicr::Session& session, const Config& config);
+        MetricsPublisher(ClientManager& server, const Config& config);
         ~MetricsPublisher();
 
         MetricsPublisher(const MetricsPublisher&) = delete;
@@ -66,7 +68,8 @@ namespace laps {
 
         struct TrackState
         {
-            std::shared_ptr<quicr::PublishTrackHandler> handler;
+            quicr::FullTrackName full_track_name;
+            std::uint64_t track_fullname_hash{ 0 };
             std::uint64_t next_object_id{ 0 };
         };
 
@@ -80,23 +83,23 @@ namespace laps {
 
         void Run();
         void PublishSample(const MetricsSample& sample);
-        void EnsureMetricsTracks(std::uint64_t connection_handle);
-        std::shared_ptr<quicr::PublishTrackHandler> CreateTrackHandler(MetricType type) const;
+        void EnsureMetricsTracks();
         quicr::FullTrackName FullTrackNameFor(MetricType type) const;
+        std::string MetricsNamespaceStr() const;
         static const char* TypeName(MetricType type);
 
         bool QueueSample(MetricsSample sample);
 
-        quicr::Session& session_;
+        ClientManager& server_;
         const Config& config_;
-        quicr::TrackNamespace metrics_namespace_;
+        std::vector<std::string> metrics_namespace_entries_;
 
         quicr::SafeQueue<MetricsSample> queue_{ kQueueLimit };
         std::atomic_bool running_{ false };
         std::thread worker_;
 
         std::mutex tracks_mutex_;
-        std::map<std::uint64_t, std::map<MetricType, TrackState>> tracks_by_connection_;
+        std::map<MetricType, TrackState> tracks_;
         std::map<std::uint64_t, RemoteInfo> remote_by_connection_;
     };
 } // namespace laps

--- a/src/metrics_publisher.h
+++ b/src/metrics_publisher.h
@@ -61,6 +61,7 @@ namespace laps {
 
         void QueueConnectionMetrics(std::uint64_t connection_handle,
                                     std::size_t publish_track_count,
+                                    std::size_t subscribe_track_count,
                                     const quicr::ConnectionMetrics& metrics);
         /**
          * @brief Queue a sample taken on a relay publish track

--- a/src/metrics_publisher.h
+++ b/src/metrics_publisher.h
@@ -62,20 +62,35 @@ namespace laps {
         void QueueConnectionMetrics(std::uint64_t connection_handle,
                                     std::size_t publish_track_count,
                                     const quicr::ConnectionMetrics& metrics);
+        /**
+         * @brief Queue a sample taken on a relay publish track
+         *
+         * @details Exported with type "subscribe". The relay publishes in order to send to a subscriber, so
+         *      the sample describes a subscriber of the relay, not a publisher.
+         */
         void QueuePublishMetrics(std::uint64_t connection_handle,
                                  const quicr::FullTrackName& track_name,
-                                 std::size_t subscriber_count,
                                  const quicr::PublishTrackMetrics& metrics);
+
+        /**
+         * @brief Queue a sample taken on a relay subscribe track
+         *
+         * @details Exported with type "publish". The relay subscribes in order to receive from a publisher,
+         *      so the sample describes a publisher to the relay, not a subscriber.
+         */
         void QueueSubscribeMetrics(std::uint64_t connection_handle,
                                    const quicr::FullTrackName& track_name,
+                                   std::size_t subscriber_count,
                                    const quicr::SubscribeTrackMetrics& metrics);
 
       private:
+        /// Exported metric type. Named for the remote role the sample describes, which is the inverse of the
+        /// relay-side handler that produced it.
         enum class MetricType : std::uint8_t
         {
             kConnection,
-            kSubscribe,
-            kPublish,
+            kSubscribe, ///< From a relay publish track: the relay sending to a subscriber
+            kPublish,   ///< From a relay subscribe track: the relay receiving from a publisher
         };
 
         struct MetricsSample

--- a/src/publish_handler.cc
+++ b/src/publish_handler.cc
@@ -72,6 +72,8 @@ namespace laps {
     void PublishTrackHandler::MetricsSampled(const quicr::PublishTrackMetrics& metrics)
     {
         const auto tfn = GetFullTrackName();
+        server_.metrics_publisher_.QueuePublishMetrics(GetConnectionId(), tfn, metrics);
+
         SPDLOG_DEBUG("Metrics track: {} ({})"
                      " objects sent: {}"
                      " bytes sent: {}"

--- a/src/publish_handler.cc
+++ b/src/publish_handler.cc
@@ -73,20 +73,6 @@ namespace laps {
     {
         const auto tfn = GetFullTrackName();
         server_.metrics_publisher_.QueuePublishMetrics(GetConnectionId(), tfn, metrics);
-
-        SPDLOG_DEBUG("Metrics track: {} ({})"
-                     " objects sent: {}"
-                     " bytes sent: {}"
-                     " object duration us: {}"
-                     " queue discards: {}"
-                     " queue size: {}",
-                     tfn.NamespaceStr(),
-                     tfn.NameStr(),
-                     metrics.objects_published,
-                     metrics.bytes_published,
-                     metrics.quic.tx_object_duration_us.avg,
-                     metrics.quic.tx_queue_discards,
-                     metrics.quic.tx_queue_size.avg);
     }
 
     bool PublishTrackHandler::SentFirstObject(uint32_t group_id, uint32_t subgroup_id)

--- a/src/publish_handler.cc
+++ b/src/publish_handler.cc
@@ -72,7 +72,9 @@ namespace laps {
     void PublishTrackHandler::MetricsSampled(const quicr::PublishTrackMetrics& metrics)
     {
         const auto tfn = GetFullTrackName();
-        server_.metrics_publisher_.QueuePublishMetrics(GetConnectionId(), tfn, metrics);
+        const auto th = quicr::TrackHash(tfn);
+        server_.metrics_publisher_.QueuePublishMetrics(
+          GetConnectionId(), tfn, server_.TrackSubscriberCount(th.track_fullname_hash), metrics);
     }
 
     bool PublishTrackHandler::SentFirstObject(uint32_t group_id, uint32_t subgroup_id)

--- a/src/publish_handler.cc
+++ b/src/publish_handler.cc
@@ -72,9 +72,7 @@ namespace laps {
     void PublishTrackHandler::MetricsSampled(const quicr::PublishTrackMetrics& metrics)
     {
         const auto tfn = GetFullTrackName();
-        const auto th = quicr::TrackHash(tfn);
-        server_.metrics_publisher_.QueuePublishMetrics(
-          GetConnectionId(), tfn, server_.TrackSubscriberCount(th.track_fullname_hash), metrics);
+        server_.metrics_publisher_.QueuePublishMetrics(GetConnectionId(), tfn, metrics);
     }
 
     bool PublishTrackHandler::SentFirstObject(uint32_t group_id, uint32_t subgroup_id)

--- a/src/publish_namespace_handler.cc
+++ b/src/publish_namespace_handler.cc
@@ -93,7 +93,7 @@ laps::PublishNamespaceHandler::UpdateTrackRanking(
 
     // Update latest tick for each publish track
     for (auto& [ta, insert_seq_num, latest_tick, conn_id] : ordered_tracks) {
-        SPDLOG_DEBUG("DEBUG: conn_id: {} ta: {} insert_seq_num: {} latest_tick: {}",
+        SPDLOG_TRACE("DEBUG: conn_id: {} ta: {} insert_seq_num: {} latest_tick: {}",
                      GetConnectionId(),
                      ta,
                      insert_seq_num,
@@ -113,7 +113,7 @@ laps::PublishNamespaceHandler::UpdateTrackRanking(
 
         // Filter out self-tracks
         if (publisher_conn_id == GetConnectionId()) {
-            SPDLOG_DEBUG("Skipping self-track {} (connection_id: {})", ta, publisher_conn_id);
+            SPDLOG_TRACE("Skipping self-track {} (connection_id: {})", ta, publisher_conn_id);
             continue;
         }
 

--- a/src/publish_namespace_handler.h
+++ b/src/publish_namespace_handler.h
@@ -24,6 +24,8 @@ namespace laps {
 
         PublishNamespaceHandler(const quicr::TrackNamespace& prefix, std::weak_ptr<timeq::tick_service> tick_service);
 
+        std::uint64_t PublishTracksCount() const { return published_tracks_.size(); }
+
         void EndSubgroup(uint64_t group_id, uint64_t subgroup_id, bool completed);
 
         quicr::PublishTrackHandler::PublishObjectStatus PublishObject(

--- a/src/state.h
+++ b/src/state.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "publish_namespace_handler.h"
+
 #include <mutex>
 #include <quicr/session.h>
 #include <set>
@@ -7,7 +9,6 @@
 namespace laps {
     class SubscribeTrackHandler;
     class PublishTrackHandler;
-    class PublishNamespaceHandler;
 
     struct State
     {
@@ -91,20 +92,14 @@ namespace laps {
          */
         std::size_t PublishTrackCount(std::uint64_t connection_handle)
         {
-            std::size_t count = 0;
-
             std::lock_guard _(state_mutex);
 
-            for (const auto& subscribe : pub_subscribes) {
-                const auto& key = subscribe.first;
-                const auto stored_connection_handle = key.second;
-
-                if (stored_connection_handle == connection_handle) {
-                    ++count;
-                }
+            const auto& metrics = conn_state_metrics.find(connection_handle);
+            if (metrics != conn_state_metrics.end()) {
+                return metrics->second.published_tracks;
             }
 
-            return count;
+            return 0;
         }
 
         /**
@@ -116,6 +111,35 @@ namespace laps {
          * @example track_handler = subscribes[track_alias, connection_handle]
          */
         std::map<std::pair<std::uint64_t, std::uint64_t>, SubscribePublishHandlerInfo> subscribes;
+
+        struct StateMetrics
+        {
+            std::uint64_t subscribed_tracks; ///< gauge; Set to the active number of subscribes
+            std::uint64_t published_tracks;  // gauge; Set to the active number of publishes
+        };
+
+        // Key is connection ID/handle
+        std::map<std::uint64_t, StateMetrics> conn_state_metrics;
+
+        /**
+         * @brief Get the count of subscribe tracks
+         *
+         * @param connection_handle     Connection handle/id
+         *
+         * @return Number of subscribes received from the connection, including the tracks matched by each of
+         *      the connection's namespace subscribes
+         */
+        std::size_t SubscribeTrackCount(std::uint64_t connection_handle)
+        {
+            std::lock_guard _(state_mutex);
+
+            const auto& metrics = conn_state_metrics.find(connection_handle);
+            if (metrics != conn_state_metrics.end()) {
+                return metrics->second.subscribed_tracks;
+            }
+
+            return 0;
+        }
 
         /**
          * Request ID to alias mapping

--- a/src/subscribe_handler.cc
+++ b/src/subscribe_handler.cc
@@ -532,6 +532,8 @@ namespace laps {
     void SubscribeTrackHandler::MetricsSampled(const quicr::SubscribeTrackMetrics& metrics)
     {
         const auto tfn = GetFullTrackName();
+        server_.metrics_publisher_.QueueSubscribeMetrics(GetConnectionId(), tfn, subscribers_.size(), metrics);
+
         SPDLOG_DEBUG("track: {} ({}) metrics subscribers: {} ", tfn.NamespaceStr(), tfn.NameStr(), subscribers_.size());
     }
 }

--- a/src/subscribe_handler.cc
+++ b/src/subscribe_handler.cc
@@ -564,6 +564,6 @@ namespace laps {
     void SubscribeTrackHandler::MetricsSampled(const quicr::SubscribeTrackMetrics& metrics)
     {
         const auto tfn = GetFullTrackName();
-        server_.metrics_publisher_.QueueSubscribeMetrics(GetConnectionId(), tfn, subscribers_.size(), metrics);
+        server_.metrics_publisher_.QueueSubscribeMetrics(GetConnectionId(), tfn, metrics);
     }
 }

--- a/src/subscribe_handler.cc
+++ b/src/subscribe_handler.cc
@@ -564,6 +564,6 @@ namespace laps {
     void SubscribeTrackHandler::MetricsSampled(const quicr::SubscribeTrackMetrics& metrics)
     {
         const auto tfn = GetFullTrackName();
-        server_.metrics_publisher_.QueueSubscribeMetrics(GetConnectionId(), tfn, metrics);
+        server_.metrics_publisher_.QueueSubscribeMetrics(GetConnectionId(), tfn, SubscriberCount(), metrics);
     }
 }

--- a/src/subscribe_handler.cc
+++ b/src/subscribe_handler.cc
@@ -163,6 +163,10 @@ namespace laps {
                                                quicr::BytesSpan data,
                                                std::optional<quicr::messages::StreamHeaderProperties> stream_mode)
     {
+        if (object_headers.track_mode.has_value()) {
+            is_datagram_ = *object_headers.track_mode == quicr::TrackMode::kDatagram;
+        }
+
         auto self_connection_handle = GetConnectionId();
 
         // Update tracked properties
@@ -533,7 +537,5 @@ namespace laps {
     {
         const auto tfn = GetFullTrackName();
         server_.metrics_publisher_.QueueSubscribeMetrics(GetConnectionId(), tfn, subscribers_.size(), metrics);
-
-        SPDLOG_DEBUG("track: {} ({}) metrics subscribers: {} ", tfn.NamespaceStr(), tfn.NameStr(), subscribers_.size());
     }
 }

--- a/src/subscribe_handler.h
+++ b/src/subscribe_handler.h
@@ -87,6 +87,13 @@ namespace laps {
 
         bool HasSubscribers() const { return !subscribers_.empty() || !sub_namespaces_.empty(); }
 
+        /**
+         * @brief Number of subscribers receiving fanout of this track via SUBSCRIBE
+         *
+         * @note Subscribers matched through a subscribe namespace are not included.
+         */
+        std::size_t SubscriberCount() const { return subscribers_.size(); }
+
       private:
         void TryProcessStreamData(uint64_t stream_id, StreamContext& stream);
 

--- a/src/track_ranking.h
+++ b/src/track_ranking.h
@@ -83,7 +83,7 @@ namespace laps {
             // Rebuild if track moved buckets or new bucket was created
             needs_rebuild = needs_rebuild || inserted;
 
-            SPDLOG_DEBUG("Update Value ta: {} prop: {} value: {} tick: {} conn_id: {}",
+            SPDLOG_TRACE("Update Value ta: {} prop: {} value: {} tick: {} conn_id: {}",
                          track_alias,
                          prop,
                          value,


### PR DESCRIPTION
Export metrics via publish track using namespace `<metrics namespace>/<relay id>`  and name `<type such as connection, subscribe, publish>`

Metrics will be emitted every time the callback is called with metrics. 

Adapters/consumers can consume metrics by using SUBSCRIBE_TRACKS on the metrics namespace. 

Instead of using a JSON lib with another deps, this has a small implementation to format the metrics in json format. 