### PR TITLE
Add heartbeat subscriber for gateway 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,8 +44,16 @@ set_target_properties(lapsRelay
 
 target_compile_definitions(lapsRelay PRIVATE SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
 
+add_library(relay_health_check_lib STATIC relay_health_check_internal.cpp)
+target_include_directories(relay_health_check_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+set_target_properties(relay_health_check_lib
+        PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS OFF)
+
 add_executable(relay_health_check relay_health_check.cpp)
-target_link_libraries(relay_health_check PRIVATE quicr)
+target_link_libraries(relay_health_check PRIVATE quicr relay_health_check_lib)
 
 target_compile_options(relay_health_check
         PRIVATE

--- a/src/relay_health_check.cpp
+++ b/src/relay_health_check.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
+#include "relay_health_check_internal.h"
+
 #include "quicr/client.h"
 #include "quicr/publish_track_handler.h"
 #include "quicr/subscribe_track_handler.h"
@@ -22,18 +24,9 @@
 #include <vector>
 
 using namespace quicr;
+using laps::relay_health::Options;
 
 namespace {
-
-    struct Options
-    {
-        std::string uri{ "moq://laps-relay:12345/relay" };
-        std::chrono::milliseconds timeout{ 5000 };
-        std::string name_space{ "libquicr/health" };
-        std::optional<std::string> name;
-        std::string message{ "libquicr relay health check" };
-        bool debug{ false };
-    };
 
     struct VerificationResult
     {
@@ -57,137 +50,16 @@ namespace {
         return predicate();
     }
 
-    std::string GetEnvOrDefault(const char* key, std::string fallback)
+    Bytes ToQuicrBytes(std::string_view value)
     {
-        const auto value = std::getenv(key);
-        if (value == nullptr || std::string_view(value).empty()) {
-            return fallback;
-        }
-        return value;
+        const auto bytes = laps::relay_health::ToBytes(value);
+        return Bytes(bytes.begin(), bytes.end());
     }
 
-    std::chrono::milliseconds ParseTimeout(std::string_view value)
-    {
-        try {
-            return std::chrono::milliseconds(std::stoul(std::string(value)));
-        } catch (const std::exception&) {
-            throw std::runtime_error("timeout must be an integer number of milliseconds");
-        }
-    }
-
-    std::vector<std::string> SplitNamespace(std::string_view value)
-    {
-        std::vector<std::string> parts;
-        std::string current;
-        for (const char ch : value) {
-            if (ch == '/' || ch == ',') {
-                if (!current.empty()) {
-                    parts.push_back(current);
-                    current.clear();
-                }
-                continue;
-            }
-            current.push_back(ch);
-        }
-
-        if (!current.empty()) {
-            parts.push_back(current);
-        }
-
-        if (parts.empty()) {
-            parts.emplace_back("health");
-        }
-
-        return parts;
-    }
-
-    Bytes ToBytes(std::string_view value)
-    {
-        Bytes bytes;
-        bytes.reserve(value.size());
-        for (const auto ch : value) {
-            bytes.push_back(static_cast<std::uint8_t>(ch));
-        }
-        return bytes;
-    }
-
-    std::string MakeDefaultTrackName()
+    std::string DefaultTrackName()
     {
         const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
-        return "probe-" + std::to_string(now);
-    }
-
-    void ApplyEnvironment(Options& options)
-    {
-        options.uri = GetEnvOrDefault("LIBQUICR_RELAY_HEALTH_URI", options.uri);
-        options.name_space = GetEnvOrDefault("LIBQUICR_RELAY_HEALTH_NAMESPACE", options.name_space);
-        options.message = GetEnvOrDefault("LIBQUICR_RELAY_HEALTH_MESSAGE", options.message);
-
-        if (const auto name = std::getenv("LIBQUICR_RELAY_HEALTH_NAME"); name != nullptr && *name != '\0') {
-            options.name = name;
-        }
-
-        if (const auto timeout = std::getenv("LIBQUICR_RELAY_HEALTH_TIMEOUT_MS");
-            timeout != nullptr && *timeout != '\0') {
-            options.timeout = ParseTimeout(timeout);
-        }
-
-        if (const auto debug = std::getenv("LIBQUICR_RELAY_HEALTH_DEBUG"); debug != nullptr) {
-            options.debug = std::string_view(debug) == "1" || std::string_view(debug) == "true";
-        }
-    }
-
-    void PrintUsage(const char* program)
-    {
-        std::cerr << "Usage: " << program
-                  << " [--uri URI] [--timeout-ms MS] [--namespace NS] [--name NAME] [--message TEXT] [--debug]\n"
-                  << "\n"
-                  << "Environment overrides:\n"
-                  << "  LIBQUICR_RELAY_HEALTH_URI\n"
-                  << "  LIBQUICR_RELAY_HEALTH_TIMEOUT_MS\n"
-                  << "  LIBQUICR_RELAY_HEALTH_NAMESPACE\n"
-                  << "  LIBQUICR_RELAY_HEALTH_NAME\n"
-                  << "  LIBQUICR_RELAY_HEALTH_MESSAGE\n"
-                  << "  LIBQUICR_RELAY_HEALTH_DEBUG\n";
-    }
-
-    Options ParseOptions(int argc, char* argv[])
-    {
-        Options options;
-        ApplyEnvironment(options);
-
-        auto require_value = [&](int& index, const std::string_view option) -> std::string {
-            if (index + 1 >= argc) {
-                throw std::runtime_error(std::string(option) + " requires a value");
-            }
-            ++index;
-            return argv[index];
-        };
-
-        for (int i = 1; i < argc; ++i) {
-            const std::string_view arg(argv[i]);
-            if (arg == "--help" || arg == "-h") {
-                PrintUsage(argv[0]);
-                std::exit(EXIT_SUCCESS);
-            }
-            if (arg == "--uri") {
-                options.uri = require_value(i, arg);
-            } else if (arg == "--timeout-ms") {
-                options.timeout = ParseTimeout(require_value(i, arg));
-            } else if (arg == "--namespace") {
-                options.name_space = require_value(i, arg);
-            } else if (arg == "--name") {
-                options.name = require_value(i, arg);
-            } else if (arg == "--message") {
-                options.message = require_value(i, arg);
-            } else if (arg == "--debug") {
-                options.debug = true;
-            } else {
-                throw std::runtime_error("unknown option: " + std::string(arg));
-            }
-        }
-
-        return options;
+        return laps::relay_health::MakeDefaultTrackName(static_cast<std::uint64_t>(now));
     }
 
     class VerifyingSubscribeTrackHandler final : public SubscribeTrackHandler
@@ -248,46 +120,32 @@ namespace {
         config.connect_uri = options.uri;
         config.transport_config.debug = options.debug;
         config.transport_config.time_queue_max_duration = 10000;
-        config.transport_config.idle_timeout_ms = static_cast<std::uint64_t>(options.timeout.count() * 2);
+        const std::uint64_t idle_multiplier = options.gateway_enabled ? 4 : 2;
+        config.transport_config.idle_timeout_ms =
+          static_cast<std::uint64_t>(options.timeout.count()) * idle_multiplier;
         return Client::Create(config);
     }
 
-    bool RunHealthCheck(const Options& options, std::string& error)
+    bool RunPubSubProbe(Client& subscriber,
+                        Client& publisher,
+                        const Options& options,
+                        const std::string& unique_suffix,
+                        std::string& error)
     {
-        const auto unique_name = options.name.value_or(MakeDefaultTrackName());
-        const auto unique_suffix = unique_name;
-        const auto expected_payload = ToBytes(options.message);
+        const auto unique_name = options.name.value_or(std::string("probe-") + unique_suffix);
+        const auto expected_payload = ToQuicrBytes(options.message);
 
         FullTrackName track;
-        track.name_space = TrackNamespace(SplitNamespace(options.name_space));
-        track.name = ToBytes(unique_name);
-
-        auto subscriber = MakeClient("relay-health-subscriber-" + unique_suffix, options);
-        auto publisher = MakeClient("relay-health-publisher-" + unique_suffix, options);
-
-        subscriber->Connect();
-        publisher->Connect();
-
-        const bool connected = WaitFor(
-          [&subscriber, &publisher]() {
-              return subscriber->GetStatus() == Transport::Status::kReady &&
-                     publisher->GetStatus() == Transport::Status::kReady;
-          },
-          options.timeout);
-        if (!connected) {
-            error = "publisher and subscriber did not both connect before timeout";
-            subscriber->Disconnect();
-            publisher->Disconnect();
-            return false;
-        }
+        track.name_space = TrackNamespace(laps::relay_health::SplitNamespace(options.name_space));
+        track.name = ToQuicrBytes(unique_name);
 
         const auto result_promise = std::make_shared<std::promise<VerificationResult>>();
         auto result_future = result_promise->get_future();
         auto sub_handler = VerifyingSubscribeTrackHandler::Create(track, expected_payload, result_promise);
         auto pub_handler = PublishTrackHandler::Create(track, TrackMode::kStream, 3, 1000, { 0, 0 });
 
-        subscriber->SubscribeTrack(sub_handler);
-        publisher->PublishTrack(pub_handler);
+        subscriber.SubscribeTrack(sub_handler);
+        publisher.PublishTrack(pub_handler);
 
         const bool ready = WaitFor(
           [&sub_handler, &pub_handler]() {
@@ -296,12 +154,10 @@ namespace {
           options.timeout);
         if (!ready) {
             std::ostringstream stream;
-            stream << "publisher/subscriber track setup timed out; subscriber status="
+            stream << "[relay] publisher/subscriber track setup timed out; subscriber status="
                    << static_cast<int>(sub_handler->GetStatus())
                    << ", publisher status=" << static_cast<int>(pub_handler->GetStatus());
             error = stream.str();
-            subscriber->Disconnect();
-            publisher->Disconnect();
             return false;
         }
 
@@ -318,28 +174,133 @@ namespace {
 
         const auto publish_status = pub_handler->PublishObject(headers, expected_payload);
         if (publish_status != PublishTrackHandler::PublishObjectStatus::kOk) {
-            error = "PublishObject failed with status " + std::to_string(static_cast<int>(publish_status));
-            subscriber->Disconnect();
-            publisher->Disconnect();
+            error = "[relay] PublishObject failed with status " + std::to_string(static_cast<int>(publish_status));
             return false;
         }
 
         if (result_future.wait_for(options.timeout) != std::future_status::ready) {
-            error = "subscriber did not receive the health-check object before timeout";
+            error = "[relay] subscriber did not receive the health-check object before timeout";
+            return false;
+        }
+
+        const auto result = result_future.get();
+        if (!result.matched) {
+            error = "[relay] " + result.error;
+            return false;
+        }
+
+        return true;
+    }
+
+    bool RunSubscribeProbe(Client& subscriber,
+                           const FullTrackName& track,
+                           const std::string& track_display,
+                           const Bytes& expected_payload,
+                           std::chrono::milliseconds timeout,
+                           std::string& error)
+    {
+        const auto result_promise = std::make_shared<std::promise<VerificationResult>>();
+        auto result_future = result_promise->get_future();
+        auto sub_handler = VerifyingSubscribeTrackHandler::Create(track, expected_payload, result_promise);
+
+        subscriber.SubscribeTrack(sub_handler);
+
+        const bool ready = WaitFor(
+          [&sub_handler]() { return sub_handler->GetStatus() == SubscribeTrackHandler::Status::kOk; }, timeout);
+        if (!ready) {
+            std::ostringstream stream;
+            stream << "[gateway] subscription setup timed out on " << track_display
+                   << "; subscriber status=" << static_cast<int>(sub_handler->GetStatus());
+            error = stream.str();
+            return false;
+        }
+
+        if (result_future.wait_for(timeout) != std::future_status::ready) {
+            error = "[gateway] subscription established but no object received on " + track_display + " within " +
+                    std::to_string(timeout.count()) + "ms";
+            return false;
+        }
+
+        const auto result = result_future.get();
+        if (!result.matched) {
+            error = "[gateway] " + result.error + " (track " + track_display + ")";
+            return false;
+        }
+
+        return true;
+    }
+
+    std::string GatewayTrackDisplay(const std::vector<std::string>& ns_parts, const std::string& name)
+    {
+        std::string out;
+        for (std::size_t i = 0; i < ns_parts.size(); ++i) {
+            if (i > 0) {
+                out.push_back('/');
+            }
+            out.append(ns_parts[i]);
+        }
+        out.push_back('/');
+        out.append(name);
+        return out;
+    }
+
+    bool RunHealthCheck(const Options& options, std::string& error)
+    {
+        const auto unique_suffix = options.name.value_or(DefaultTrackName());
+
+        auto subscriber = MakeClient("relay-health-subscriber-" + unique_suffix, options);
+        auto publisher = MakeClient("relay-health-publisher-" + unique_suffix, options);
+
+        subscriber->Connect();
+        publisher->Connect();
+
+        const bool connected = WaitFor(
+          [&subscriber, &publisher]() {
+              return subscriber->GetStatus() == Transport::Status::kReady &&
+                     publisher->GetStatus() == Transport::Status::kReady;
+          },
+          options.timeout);
+        if (!connected) {
+            error = "[relay] publisher and subscriber did not both connect before timeout";
             subscriber->Disconnect();
             publisher->Disconnect();
             return false;
         }
 
-        const auto result = result_future.get();
-        subscriber->Disconnect();
-        publisher->Disconnect();
-
-        if (!result.matched) {
-            error = result.error;
+        const bool relay_ok = RunPubSubProbe(*subscriber, *publisher, options, unique_suffix, error);
+        if (!relay_ok) {
+            subscriber->Disconnect();
+            publisher->Disconnect();
             return false;
         }
 
+        if (options.gateway_enabled) {
+            if (options.gateway_name.empty()) {
+                error = "[gateway] LIBQUICR_GATEWAY_HEALTH_NAME (or --gateway-name) is empty";
+                subscriber->Disconnect();
+                publisher->Disconnect();
+                return false;
+            }
+
+            const auto ns_parts = laps::relay_health::SplitNamespace(options.gateway_namespace);
+            FullTrackName gateway_track;
+            gateway_track.name_space = TrackNamespace(ns_parts);
+            gateway_track.name = ToQuicrBytes(options.gateway_name);
+
+            const auto expected_payload = ToQuicrBytes(options.gateway_message);
+            const auto display = GatewayTrackDisplay(ns_parts, options.gateway_name);
+
+            const bool gateway_ok =
+              RunSubscribeProbe(*subscriber, gateway_track, display, expected_payload, options.timeout, error);
+            if (!gateway_ok) {
+                subscriber->Disconnect();
+                publisher->Disconnect();
+                return false;
+            }
+        }
+
+        subscriber->Disconnect();
+        publisher->Disconnect();
         return true;
     }
 }
@@ -348,7 +309,7 @@ int
 main(int argc, char* argv[])
 {
     try {
-        const auto options = ParseOptions(argc, argv);
+        const auto options = laps::relay_health::ParseOptions(argc, argv);
         spdlog::set_level(options.debug ? spdlog::level::debug : spdlog::level::off);
 
         std::string error;

--- a/src/relay_health_check_internal.cpp
+++ b/src/relay_health_check_internal.cpp
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "relay_health_check_internal.h"
+
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+
+namespace laps {
+namespace relay_health {
+
+    std::string GetEnvOrDefault(const char* key, std::string fallback)
+    {
+        const auto value = std::getenv(key);
+        if (value == nullptr || std::string_view(value).empty()) {
+            return fallback;
+        }
+        return value;
+    }
+
+    std::chrono::milliseconds ParseTimeout(std::string_view value)
+    {
+        try {
+            const auto text = std::string(value);
+            std::size_t consumed = 0;
+            const auto parsed = std::stoul(text, &consumed);
+            if (consumed != text.size()) {
+                throw std::runtime_error("timeout must be an integer number of milliseconds");
+            }
+            return std::chrono::milliseconds(parsed);
+        } catch (const std::runtime_error&) {
+            throw;
+        } catch (const std::exception&) {
+            throw std::runtime_error("timeout must be an integer number of milliseconds");
+        }
+    }
+
+    std::vector<std::string> SplitNamespace(std::string_view value)
+    {
+        std::vector<std::string> parts;
+        std::string current;
+        for (const char ch : value) {
+            if (ch == '/' || ch == ',') {
+                if (!current.empty()) {
+                    parts.push_back(current);
+                    current.clear();
+                }
+                continue;
+            }
+            current.push_back(ch);
+        }
+
+        if (!current.empty()) {
+            parts.push_back(current);
+        }
+
+        if (parts.empty()) {
+            parts.emplace_back("health");
+        }
+
+        return parts;
+    }
+
+    std::vector<std::uint8_t> ToBytes(std::string_view value)
+    {
+        std::vector<std::uint8_t> bytes;
+        bytes.reserve(value.size());
+        for (const auto ch : value) {
+            bytes.push_back(static_cast<std::uint8_t>(ch));
+        }
+        return bytes;
+    }
+
+    std::string MakeDefaultTrackName(std::uint64_t clock_value)
+    {
+        return "probe-" + std::to_string(clock_value);
+    }
+
+    void ApplyEnvironment(Options& options)
+    {
+        options.uri = GetEnvOrDefault("LIBQUICR_RELAY_HEALTH_URI", options.uri);
+        options.name_space = GetEnvOrDefault("LIBQUICR_RELAY_HEALTH_NAMESPACE", options.name_space);
+        options.message = GetEnvOrDefault("LIBQUICR_RELAY_HEALTH_MESSAGE", options.message);
+
+        if (const auto name = std::getenv("LIBQUICR_RELAY_HEALTH_NAME"); name != nullptr && *name != '\0') {
+            options.name = name;
+        }
+
+        if (const auto timeout = std::getenv("LIBQUICR_RELAY_HEALTH_TIMEOUT_MS");
+            timeout != nullptr && *timeout != '\0') {
+            options.timeout = ParseTimeout(timeout);
+        }
+
+        if (const auto debug = std::getenv("LIBQUICR_RELAY_HEALTH_DEBUG"); debug != nullptr && *debug != '\0') {
+            options.debug = std::string_view(debug) == "1" || std::string_view(debug) == "true";
+        }
+
+        options.gateway_namespace =
+          GetEnvOrDefault("LIBQUICR_GATEWAY_HEALTH_NAMESPACE", options.gateway_namespace);
+        options.gateway_name = GetEnvOrDefault("LIBQUICR_GATEWAY_HEALTH_NAME", options.gateway_name);
+        options.gateway_message = GetEnvOrDefault("LIBQUICR_GATEWAY_HEALTH_MESSAGE", options.gateway_message);
+
+        if (const auto enabled = std::getenv("LIBQUICR_GATEWAY_HEALTH_ENABLED");
+            enabled != nullptr && *enabled != '\0') {
+            options.gateway_enabled = std::string_view(enabled) == "1" || std::string_view(enabled) == "true";
+        }
+    }
+
+    void PrintUsage(std::ostream& out, const char* program)
+    {
+        out << "Usage: " << program
+            << " [--uri URI] [--timeout-ms MS] [--namespace NS] [--name NAME] [--message TEXT] [--debug]\n"
+            << "       [--gateway] [--gateway-namespace NS] [--gateway-name NAME] [--gateway-message TEXT]\n"
+            << "\n"
+            << "Environment overrides:\n"
+            << "  LIBQUICR_RELAY_HEALTH_URI\n"
+            << "  LIBQUICR_RELAY_HEALTH_TIMEOUT_MS\n"
+            << "  LIBQUICR_RELAY_HEALTH_NAMESPACE\n"
+            << "  LIBQUICR_RELAY_HEALTH_NAME\n"
+            << "  LIBQUICR_RELAY_HEALTH_MESSAGE\n"
+            << "  LIBQUICR_RELAY_HEALTH_DEBUG\n"
+            << "  LIBQUICR_GATEWAY_HEALTH_ENABLED    (\"1\" or \"true\" enables the gateway subscribe probe)\n"
+            << "  LIBQUICR_GATEWAY_HEALTH_NAMESPACE  (default: frontline.m10x.org/health)\n"
+            << "  LIBQUICR_GATEWAY_HEALTH_NAME       (default: health_check)\n"
+            << "  LIBQUICR_GATEWAY_HEALTH_MESSAGE    (default: pong)\n";
+    }
+
+    Options ParseOptions(int argc, char* argv[])
+    {
+        Options options;
+        ApplyEnvironment(options);
+
+        auto require_value = [&](int& index, const std::string_view option) -> std::string {
+            if (index + 1 >= argc) {
+                throw std::runtime_error(std::string(option) + " requires a value");
+            }
+            ++index;
+            return argv[index];
+        };
+
+        for (int i = 1; i < argc; ++i) {
+            const std::string_view arg(argv[i]);
+            if (arg == "--help" || arg == "-h") {
+                PrintUsage(std::cerr, argv[0]);
+                std::exit(EXIT_SUCCESS);
+            }
+            if (arg == "--uri") {
+                options.uri = require_value(i, arg);
+            } else if (arg == "--timeout-ms") {
+                options.timeout = ParseTimeout(require_value(i, arg));
+            } else if (arg == "--namespace") {
+                options.name_space = require_value(i, arg);
+            } else if (arg == "--name") {
+                options.name = require_value(i, arg);
+            } else if (arg == "--message") {
+                options.message = require_value(i, arg);
+            } else if (arg == "--debug") {
+                options.debug = true;
+            } else if (arg == "--gateway") {
+                options.gateway_enabled = true;
+            } else if (arg == "--gateway-namespace") {
+                options.gateway_namespace = require_value(i, arg);
+            } else if (arg == "--gateway-name") {
+                options.gateway_name = require_value(i, arg);
+            } else if (arg == "--gateway-message") {
+                options.gateway_message = require_value(i, arg);
+            } else {
+                throw std::runtime_error("unknown option: " + std::string(arg));
+            }
+        }
+
+        return options;
+    }
+
+}
+}

--- a/src/relay_health_check_internal.h
+++ b/src/relay_health_check_internal.h
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <iosfwd>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace laps {
+namespace relay_health {
+
+    struct Options
+    {
+        std::string uri{ "moq://laps-relay:12345/relay" };
+        std::chrono::milliseconds timeout{ 5000 };
+        std::string name_space{ "libquicr/health" };
+        std::optional<std::string> name;
+        std::string message{ "libquicr relay health check" };
+        bool debug{ false };
+
+        bool gateway_enabled{ false };
+        std::string gateway_namespace{ "frontline.m10x.org/health" };
+        std::string gateway_name{ "health_check" };
+        std::string gateway_message{ "pong" };
+    };
+
+    std::string GetEnvOrDefault(const char* key, std::string fallback);
+
+    std::chrono::milliseconds ParseTimeout(std::string_view value);
+
+    std::vector<std::string> SplitNamespace(std::string_view value);
+
+    std::vector<std::uint8_t> ToBytes(std::string_view value);
+
+    std::string MakeDefaultTrackName(std::uint64_t clock_value);
+
+    void ApplyEnvironment(Options& options);
+
+    Options ParseOptions(int argc, char* argv[]);
+
+    void PrintUsage(std::ostream& out, const char* program);
+
+}
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(laps_test
         peering_data_header.cc
         peering_info_base.cc
         track_ranking.cc
+        relay_health_check_test.cc
 
         ../src/peering/messages/connect.cc
         ../src/peering/messages/connect_response.cc
@@ -23,7 +24,7 @@ add_executable(laps_test
 )
 target_include_directories(laps_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
-target_link_libraries(laps_test PRIVATE quicr doctest::doctest)
+target_link_libraries(laps_test PRIVATE quicr doctest::doctest relay_health_check_lib)
 
 target_compile_options(laps_test
         PRIVATE
@@ -51,3 +52,19 @@ endif ()
 
 include(${CMAKE_SOURCE_DIR}/dependencies/doctest/scripts/cmake/doctest.cmake)
 doctest_discover_tests(laps_test)
+
+# Scoped test target for relay_health_check helpers — kept separate so it stays
+# green even when broader peering tests are temporarily out of sync with
+# libquicr's evolving public API.
+add_executable(relay_health_check_test
+        main.cc
+        relay_health_check_test.cc
+)
+target_include_directories(relay_health_check_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(relay_health_check_test PRIVATE doctest::doctest relay_health_check_lib)
+set_target_properties(relay_health_check_test
+        PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS ON)
+doctest_discover_tests(relay_health_check_test)

--- a/test/relay_health_check_test.cc
+++ b/test/relay_health_check_test.cc
@@ -1,0 +1,348 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <doctest/doctest.h>
+
+#include "relay_health_check_internal.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace {
+
+    using laps::relay_health::ApplyEnvironment;
+    using laps::relay_health::GetEnvOrDefault;
+    using laps::relay_health::MakeDefaultTrackName;
+    using laps::relay_health::Options;
+    using laps::relay_health::ParseOptions;
+    using laps::relay_health::ParseTimeout;
+    using laps::relay_health::SplitNamespace;
+    using laps::relay_health::ToBytes;
+
+    class ScopedEnv
+    {
+      public:
+        explicit ScopedEnv(std::vector<const char*> keys)
+        {
+            keys_.reserve(keys.size());
+            for (const auto* key : keys) {
+                Snapshot snapshot;
+                snapshot.key = key;
+                if (const auto* current = std::getenv(key); current != nullptr) {
+                    snapshot.had_value = true;
+                    snapshot.original = current;
+                }
+                keys_.push_back(std::move(snapshot));
+                ::unsetenv(key);
+            }
+        }
+
+        ScopedEnv(const ScopedEnv&) = delete;
+        ScopedEnv& operator=(const ScopedEnv&) = delete;
+
+        ~ScopedEnv()
+        {
+            for (const auto& snapshot : keys_) {
+                if (snapshot.had_value) {
+                    ::setenv(snapshot.key, snapshot.original.c_str(), 1);
+                } else {
+                    ::unsetenv(snapshot.key);
+                }
+            }
+        }
+
+        void Set(const char* key, const char* value) { ::setenv(key, value, 1); }
+
+      private:
+        struct Snapshot
+        {
+            const char* key{ nullptr };
+            bool had_value{ false };
+            std::string original;
+        };
+
+        std::vector<Snapshot> keys_;
+    };
+
+    const std::vector<const char*> kAllEnvKeys = {
+        "LIBQUICR_RELAY_HEALTH_URI",
+        "LIBQUICR_RELAY_HEALTH_TIMEOUT_MS",
+        "LIBQUICR_RELAY_HEALTH_NAMESPACE",
+        "LIBQUICR_RELAY_HEALTH_NAME",
+        "LIBQUICR_RELAY_HEALTH_MESSAGE",
+        "LIBQUICR_RELAY_HEALTH_DEBUG",
+        "LIBQUICR_GATEWAY_HEALTH_ENABLED",
+        "LIBQUICR_GATEWAY_HEALTH_NAMESPACE",
+        "LIBQUICR_GATEWAY_HEALTH_NAME",
+        "LIBQUICR_GATEWAY_HEALTH_MESSAGE",
+    };
+
+}
+
+TEST_CASE("SplitNamespace: relay default")
+{
+    const auto parts = SplitNamespace("libquicr/health");
+    REQUIRE(parts.size() == 2);
+    CHECK(parts[0] == "libquicr");
+    CHECK(parts[1] == "health");
+}
+
+TEST_CASE("SplitNamespace: gateway default matches [frontline.m10x.org, health]")
+{
+    const auto parts = SplitNamespace("frontline.m10x.org/health");
+    REQUIRE(parts.size() == 2);
+    CHECK(parts[0] == "frontline.m10x.org");
+    CHECK(parts[1] == "health");
+}
+
+TEST_CASE("SplitNamespace: comma separator")
+{
+    const auto parts = SplitNamespace("a,b,c");
+    REQUIRE(parts.size() == 3);
+    CHECK(parts[0] == "a");
+    CHECK(parts[1] == "b");
+    CHECK(parts[2] == "c");
+}
+
+TEST_CASE("SplitNamespace: leading/trailing slashes are ignored")
+{
+    const auto parts = SplitNamespace("/leading/slash/");
+    REQUIRE(parts.size() == 2);
+    CHECK(parts[0] == "leading");
+    CHECK(parts[1] == "slash");
+}
+
+TEST_CASE("SplitNamespace: empty string falls back to health")
+{
+    const auto parts = SplitNamespace("");
+    REQUIRE(parts.size() == 1);
+    CHECK(parts[0] == "health");
+}
+
+TEST_CASE("SplitNamespace: single token")
+{
+    const auto parts = SplitNamespace("single");
+    REQUIRE(parts.size() == 1);
+    CHECK(parts[0] == "single");
+}
+
+TEST_CASE("ToBytes: ping payload")
+{
+    const auto bytes = ToBytes("ping");
+    REQUIRE(bytes.size() == 4);
+    CHECK(bytes[0] == static_cast<std::uint8_t>('p'));
+    CHECK(bytes[1] == static_cast<std::uint8_t>('i'));
+    CHECK(bytes[2] == static_cast<std::uint8_t>('n'));
+    CHECK(bytes[3] == static_cast<std::uint8_t>('g'));
+}
+
+TEST_CASE("ToBytes: empty")
+{
+    CHECK(ToBytes("").empty());
+}
+
+TEST_CASE("ParseTimeout: valid integer")
+{
+    CHECK(ParseTimeout("5000") == std::chrono::milliseconds(5000));
+    CHECK(ParseTimeout("0") == std::chrono::milliseconds(0));
+}
+
+TEST_CASE("ParseTimeout: non-numeric rejected")
+{
+    CHECK_THROWS_AS(ParseTimeout("not-a-number"), std::runtime_error);
+}
+
+TEST_CASE("ParseTimeout: trailing unit rejected")
+{
+    CHECK_THROWS_AS(ParseTimeout("5000ms"), std::runtime_error);
+}
+
+TEST_CASE("GetEnvOrDefault: unset returns fallback")
+{
+    ScopedEnv env({ "LAPS_TEST_UNSET_KEY" });
+    CHECK(GetEnvOrDefault("LAPS_TEST_UNSET_KEY", "fallback") == "fallback");
+}
+
+TEST_CASE("GetEnvOrDefault: set returns value")
+{
+    ScopedEnv env({ "LAPS_TEST_SET_KEY" });
+    env.Set("LAPS_TEST_SET_KEY", "actual");
+    CHECK(GetEnvOrDefault("LAPS_TEST_SET_KEY", "fallback") == "actual");
+}
+
+TEST_CASE("GetEnvOrDefault: empty value returns fallback")
+{
+    ScopedEnv env({ "LAPS_TEST_EMPTY_KEY" });
+    env.Set("LAPS_TEST_EMPTY_KEY", "");
+    CHECK(GetEnvOrDefault("LAPS_TEST_EMPTY_KEY", "fallback") == "fallback");
+}
+
+TEST_CASE("ApplyEnvironment: defaults preserved when nothing is set (relay regression baseline)")
+{
+    ScopedEnv env(kAllEnvKeys);
+
+    Options options;
+    ApplyEnvironment(options);
+
+    CHECK(options.uri == "moq://laps-relay:12345/relay");
+    CHECK(options.timeout == std::chrono::milliseconds(5000));
+    CHECK(options.name_space == "libquicr/health");
+    CHECK_FALSE(options.name.has_value());
+    CHECK(options.message == "libquicr relay health check");
+    CHECK_FALSE(options.debug);
+
+    CHECK_FALSE(options.gateway_enabled);
+    CHECK(options.gateway_namespace == "frontline.m10x.org/health");
+    CHECK(options.gateway_name == "health_check");
+    CHECK(options.gateway_message == "pong");
+}
+
+TEST_CASE("ApplyEnvironment: relay overrides picked up")
+{
+    ScopedEnv env(kAllEnvKeys);
+    env.Set("LIBQUICR_RELAY_HEALTH_URI", "moq://other:1234/relay");
+    env.Set("LIBQUICR_RELAY_HEALTH_NAMESPACE", "custom/relay/ns");
+    env.Set("LIBQUICR_RELAY_HEALTH_NAME", "fixed-name");
+    env.Set("LIBQUICR_RELAY_HEALTH_MESSAGE", "custom message");
+    env.Set("LIBQUICR_RELAY_HEALTH_TIMEOUT_MS", "1234");
+    env.Set("LIBQUICR_RELAY_HEALTH_DEBUG", "1");
+
+    Options options;
+    ApplyEnvironment(options);
+
+    CHECK(options.uri == "moq://other:1234/relay");
+    CHECK(options.name_space == "custom/relay/ns");
+    REQUIRE(options.name.has_value());
+    CHECK(*options.name == "fixed-name");
+    CHECK(options.message == "custom message");
+    CHECK(options.timeout == std::chrono::milliseconds(1234));
+    CHECK(options.debug);
+}
+
+TEST_CASE("ApplyEnvironment: gateway defaults are stable")
+{
+    ScopedEnv env(kAllEnvKeys);
+
+    Options options;
+    ApplyEnvironment(options);
+
+    CHECK_FALSE(options.gateway_enabled);
+    CHECK(options.gateway_namespace == "frontline.m10x.org/health");
+    CHECK(options.gateway_name == "health_check");
+    CHECK(options.gateway_message == "pong");
+
+    const auto ns = SplitNamespace(options.gateway_namespace);
+    REQUIRE(ns.size() == 2);
+    CHECK(ns[0] == "frontline.m10x.org");
+    CHECK(ns[1] == "health");
+}
+
+TEST_CASE("ApplyEnvironment: gateway enable toggle only accepts 1/true")
+{
+    for (const char* truthy : { "1", "true" }) {
+        ScopedEnv env(kAllEnvKeys);
+        env.Set("LIBQUICR_GATEWAY_HEALTH_ENABLED", truthy);
+        Options options;
+        ApplyEnvironment(options);
+        CHECK(options.gateway_enabled);
+    }
+
+    for (const char* falsy : { "0", "false", "yes", "TRUE", "on" }) {
+        ScopedEnv env(kAllEnvKeys);
+        env.Set("LIBQUICR_GATEWAY_HEALTH_ENABLED", falsy);
+        Options options;
+        ApplyEnvironment(options);
+        CHECK_FALSE(options.gateway_enabled);
+    }
+}
+
+TEST_CASE("ApplyEnvironment: gateway overrides do not implicitly enable")
+{
+    ScopedEnv env(kAllEnvKeys);
+    env.Set("LIBQUICR_GATEWAY_HEALTH_NAMESPACE", "other.example.org/health");
+    env.Set("LIBQUICR_GATEWAY_HEALTH_NAME", "other_check");
+    env.Set("LIBQUICR_GATEWAY_HEALTH_MESSAGE", "beacon");
+
+    Options options;
+    ApplyEnvironment(options);
+
+    CHECK_FALSE(options.gateway_enabled);
+    CHECK(options.gateway_namespace == "other.example.org/health");
+    CHECK(options.gateway_name == "other_check");
+    CHECK(options.gateway_message == "beacon");
+}
+
+TEST_CASE("ParseOptions: CLI overrides env for relay probe")
+{
+    ScopedEnv env(kAllEnvKeys);
+    env.Set("LIBQUICR_RELAY_HEALTH_URI", "moq://env-uri:1/relay");
+
+    const char* argv[] = { "relay_health_check", "--uri", "moq://cli-uri:2/relay" };
+    const int argc = sizeof(argv) / sizeof(argv[0]);
+
+    const auto options = ParseOptions(argc, const_cast<char**>(argv));
+    CHECK(options.uri == "moq://cli-uri:2/relay");
+}
+
+TEST_CASE("ParseOptions: --gateway enables probe with default namespace/name/message")
+{
+    ScopedEnv env(kAllEnvKeys);
+
+    const char* argv[] = { "relay_health_check", "--gateway" };
+    const int argc = sizeof(argv) / sizeof(argv[0]);
+
+    const auto options = ParseOptions(argc, const_cast<char**>(argv));
+    CHECK(options.gateway_enabled);
+    CHECK(options.gateway_namespace == "frontline.m10x.org/health");
+    CHECK(options.gateway_name == "health_check");
+    CHECK(options.gateway_message == "pong");
+}
+
+TEST_CASE("ParseOptions: gateway CLI flags override env")
+{
+    ScopedEnv env(kAllEnvKeys);
+    env.Set("LIBQUICR_GATEWAY_HEALTH_NAMESPACE", "env/ns");
+    env.Set("LIBQUICR_GATEWAY_HEALTH_NAME", "env-name");
+    env.Set("LIBQUICR_GATEWAY_HEALTH_MESSAGE", "env-msg");
+
+    const char* argv[] = { "relay_health_check",
+                           "--gateway",
+                           "--gateway-namespace",
+                           "cli/ns",
+                           "--gateway-name",
+                           "cli-name",
+                           "--gateway-message",
+                           "cli-msg" };
+    const int argc = sizeof(argv) / sizeof(argv[0]);
+
+    const auto options = ParseOptions(argc, const_cast<char**>(argv));
+    CHECK(options.gateway_enabled);
+    CHECK(options.gateway_namespace == "cli/ns");
+    CHECK(options.gateway_name == "cli-name");
+    CHECK(options.gateway_message == "cli-msg");
+}
+
+TEST_CASE("ParseOptions: unknown flag rejected")
+{
+    ScopedEnv env(kAllEnvKeys);
+    const char* argv[] = { "relay_health_check", "--nope" };
+    const int argc = sizeof(argv) / sizeof(argv[0]);
+    CHECK_THROWS_AS(ParseOptions(argc, const_cast<char**>(argv)), std::runtime_error);
+}
+
+TEST_CASE("ParseOptions: --uri missing value rejected")
+{
+    ScopedEnv env(kAllEnvKeys);
+    const char* argv[] = { "relay_health_check", "--uri" };
+    const int argc = sizeof(argv) / sizeof(argv[0]);
+    CHECK_THROWS_AS(ParseOptions(argc, const_cast<char**>(argv)), std::runtime_error);
+}
+
+TEST_CASE("MakeDefaultTrackName: deterministic for a given clock value")
+{
+    CHECK(MakeDefaultTrackName(0) == "probe-0");
+    CHECK(MakeDefaultTrackName(42) == "probe-42");
+}


### PR DESCRIPTION
1. Adding support for heartbeat via subscribing to 
namespace: frontline.m10x.org/health, 
trackname: health_check
2. Adding 25 unit tests for relay_health_check